### PR TITLE
 Add NightLight view

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ vala_precompile (VALA_C ${CMAKE_PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/config.vala
     DisplayPlug.vala
     SettingsDaemon.vala
+    Views/NightLightView.vala
     Widgets/DisplaysOverlay.vala
     Widgets/DisplayWidget.vala
     Widgets/DisplayWindow.vala

--- a/src/DisplayPlug.vala
+++ b/src/DisplayPlug.vala
@@ -99,6 +99,7 @@ public class Display.Plug : Switchboard.Plug {
             } else {
                 stack.visible_child_name = "displays";
             }
+
             stack.show_all ();
         }
     }

--- a/src/DisplayPlug.vala
+++ b/src/DisplayPlug.vala
@@ -29,6 +29,7 @@ public class Display.Plug : Switchboard.Plug {
     public Plug () {
         var settings = new Gee.TreeMap<string, string?> (null, null);
         settings.set ("display", null);
+        settings.set ("display/night-light", "night-light");
         Object (category: Category.HARDWARE,
                 code_name: Build.PLUGCODENAME,
                 display_name: _("Displays"),
@@ -53,7 +54,7 @@ public class Display.Plug : Switchboard.Plug {
 
                     stack = new Gtk.Stack ();
                     stack.add_titled (displays_view, "displays", _("Displays"));
-                    stack.add_titled (nightlight_view, "nightlight", _("Night Light"));
+                    stack.add_titled (nightlight_view, "night-light", _("Night Light"));
 
                     var stack_switcher = new Gtk.StackSwitcher ();
                     stack_switcher.halign = Gtk.Align.CENTER;
@@ -98,8 +99,8 @@ public class Display.Plug : Switchboard.Plug {
 
     public override void search_callback (string location) {
         if (stack != null) {
-            if (location == "nightlight") {
-                stack.visible_child_name = "nightlight";
+            if (location == "night-light") {
+                stack.visible_child_name = "night-light";
             } else {
                 stack.visible_child_name = "displays";
             }
@@ -114,7 +115,7 @@ public class Display.Plug : Switchboard.Plug {
         search_results.set ("%s → %s".printf (display_name, _("Screen Rotation")), "");
         search_results.set ("%s → %s".printf (display_name, _("Primary display")), "");
         search_results.set ("%s → %s".printf (display_name, _("Screen mirroring")), "");
-        search_results.set ("%s → %s".printf (display_name, _("Night Light")), "nightlight");
+        search_results.set ("%s → %s".printf (display_name, _("Night Light")), "night-light");
         return search_results;
     }
 

--- a/src/DisplayPlug.vala
+++ b/src/DisplayPlug.vala
@@ -23,6 +23,7 @@
 public class Display.Plug : Switchboard.Plug {
     public static Plug plug;
     private Gtk.Grid grid;
+    private Gtk.Stack? stack;
     private DisplaysView displays_view;
 
     public Plug () {
@@ -50,7 +51,7 @@ public class Display.Plug : Switchboard.Plug {
 
                     var nightlight_view = new NightLightView ();
 
-                    var stack = new Gtk.Stack ();
+                    stack = new Gtk.Stack ();
                     stack.add_titled (displays_view, "displays", _("Displays"));
                     stack.add_titled (nightlight_view, "nightlight", _("Night Light"));
 
@@ -62,6 +63,14 @@ public class Display.Plug : Switchboard.Plug {
 
                     grid.add (stack_switcher);
                     grid.add (stack);
+
+                    stack.notify["visible-child"].connect (() => {
+                        if (stack.visible_child == displays_view) {
+                            displays_view.displays_overlay.show_windows ();
+                        } else {
+                            displays_view.displays_overlay.hide_windows ();
+                        }
+                    });
                 }
             } else {
                 grid.add (displays_view);
@@ -74,7 +83,13 @@ public class Display.Plug : Switchboard.Plug {
     }
 
     public override void shown () {
-        displays_view.displays_overlay.show_windows ();
+        if (stack != null) {
+            if (stack.visible_child == displays_view) {
+                displays_view.displays_overlay.show_windows ();
+            }
+        } else {
+            displays_view.displays_overlay.show_windows ();
+        }
     }
 
     public override void hidden () {

--- a/src/DisplayPlug.vala
+++ b/src/DisplayPlug.vala
@@ -47,32 +47,29 @@ public class Display.Plug : Switchboard.Plug {
             grid.orientation = Gtk.Orientation.VERTICAL;
 
             var interface_settings_schema = SettingsSchemaSource.get_default ().lookup ("org.gnome.settings-daemon.plugins.color", false);
-            if (interface_settings_schema != null) {
-                if (interface_settings_schema.has_key ("night-light-enabled")) {
+            if (interface_settings_schema != null) && interface_settings_schema.has_key ("night-light-enabled")) {
+                var nightlight_view = new NightLightView ();
 
-                    var nightlight_view = new NightLightView ();
+                stack = new Gtk.Stack ();
+                stack.add_titled (displays_view, "displays", _("Displays"));
+                stack.add_titled (nightlight_view, "night-light", _("Night Light"));
 
-                    stack = new Gtk.Stack ();
-                    stack.add_titled (displays_view, "displays", _("Displays"));
-                    stack.add_titled (nightlight_view, "night-light", _("Night Light"));
+                var stack_switcher = new Gtk.StackSwitcher ();
+                stack_switcher.halign = Gtk.Align.CENTER;
+                stack_switcher.homogeneous = true;
+                stack_switcher.margin = 12;
+                stack_switcher.stack = stack;
 
-                    var stack_switcher = new Gtk.StackSwitcher ();
-                    stack_switcher.halign = Gtk.Align.CENTER;
-                    stack_switcher.homogeneous = true;
-                    stack_switcher.margin = 12;
-                    stack_switcher.stack = stack;
+                grid.add (stack_switcher);
+                grid.add (stack);
 
-                    grid.add (stack_switcher);
-                    grid.add (stack);
-
-                    stack.notify["visible-child"].connect (() => {
-                        if (stack.visible_child == displays_view) {
-                            displays_view.displays_overlay.show_windows ();
-                        } else {
-                            displays_view.displays_overlay.hide_windows ();
-                        }
-                    });
-                }
+                stack.notify["visible-child"].connect (() => {
+                    if (stack.visible_child == displays_view) {
+                        displays_view.displays_overlay.show_windows ();
+                    } else {
+                        displays_view.displays_overlay.hide_windows ();
+                    }
+                });
             } else {
                 grid.add (displays_view);
             }

--- a/src/DisplayPlug.vala
+++ b/src/DisplayPlug.vala
@@ -47,7 +47,7 @@ public class Display.Plug : Switchboard.Plug {
             grid.orientation = Gtk.Orientation.VERTICAL;
 
             var interface_settings_schema = SettingsSchemaSource.get_default ().lookup ("org.gnome.settings-daemon.plugins.color", false);
-            if (interface_settings_schema != null) && interface_settings_schema.has_key ("night-light-enabled")) {
+            if (interface_settings_schema != null && interface_settings_schema.has_key ("night-light-enabled")) {
                 var nightlight_view = new NightLightView ();
 
                 stack = new Gtk.Stack ();
@@ -81,10 +81,8 @@ public class Display.Plug : Switchboard.Plug {
     }
 
     public override void shown () {
-        if (stack != null) {
-            if (stack.visible_child == displays_view) {
+        if (stack != null && stack.visible_child == displays_view) {
                 displays_view.displays_overlay.show_windows ();
-            }
         } else {
             displays_view.displays_overlay.show_windows ();
         }

--- a/src/DisplayPlug.vala
+++ b/src/DisplayPlug.vala
@@ -41,22 +41,32 @@ public class Display.Plug : Switchboard.Plug {
         if (grid == null) {
             displays_view = new DisplaysView ();
 
-            var nightlight_view = new NightLightView ();
-
-            var stack = new Gtk.Stack ();
-            stack.add_titled (displays_view, "displays", _("Displays"));
-            stack.add_titled (nightlight_view, "nightlight", _("Night Light"));
-
-            var stack_switcher = new Gtk.StackSwitcher ();
-            stack_switcher.halign = Gtk.Align.CENTER;
-            stack_switcher.homogeneous = true;
-            stack_switcher.margin = 12;
-            stack_switcher.stack = stack;
-
             grid = new Gtk.Grid ();
             grid.orientation = Gtk.Orientation.VERTICAL;
-            grid.add (stack_switcher);
-            grid.add (stack);
+
+            var interface_settings_schema = SettingsSchemaSource.get_default ().lookup ("org.gnome.settings-daemon.plugins.color", false);
+            if (interface_settings_schema != null) {
+                if (interface_settings_schema.has_key ("night-light-enabled")) {
+
+                    var nightlight_view = new NightLightView ();
+
+                    var stack = new Gtk.Stack ();
+                    stack.add_titled (displays_view, "displays", _("Displays"));
+                    stack.add_titled (nightlight_view, "nightlight", _("Night Light"));
+
+                    var stack_switcher = new Gtk.StackSwitcher ();
+                    stack_switcher.halign = Gtk.Align.CENTER;
+                    stack_switcher.homogeneous = true;
+                    stack_switcher.margin = 12;
+                    stack_switcher.stack = stack;
+
+                    grid.add (stack_switcher);
+                    grid.add (stack);
+                }
+            } else {
+                grid.add (displays_view);
+            }
+
             grid.show_all ();
         }
 

--- a/src/DisplayPlug.vala
+++ b/src/DisplayPlug.vala
@@ -97,7 +97,14 @@ public class Display.Plug : Switchboard.Plug {
     }
 
     public override void search_callback (string location) {
-        
+        if (stack != null) {
+            if (location == "nightlight") {
+                stack.visible_child_name = "nightlight";
+            } else {
+                stack.visible_child_name = "displays";
+            }
+            stack.show_all ();
+        }
     }
 
     // 'search' returns results like ("Keyboard → Behavior → Duration", "keyboard<sep>behavior")
@@ -107,6 +114,7 @@ public class Display.Plug : Switchboard.Plug {
         search_results.set ("%s → %s".printf (display_name, _("Screen Rotation")), "");
         search_results.set ("%s → %s".printf (display_name, _("Primary display")), "");
         search_results.set ("%s → %s".printf (display_name, _("Screen mirroring")), "");
+        search_results.set ("%s → %s".printf (display_name, _("Night Light")), "nightlight");
         return search_results;
     }
 

--- a/src/Views/DisplaysView.vala
+++ b/src/Views/DisplaysView.vala
@@ -90,7 +90,7 @@ public class Display.DisplaysView : Gtk.Grid {
             action_bar.pack_end (button_grid);
 
             orientation = Gtk.Orientation.VERTICAL;
-            column_spacing = 6;
+            add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
             add (stack);
             add (action_bar);
             show_all ();

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -19,7 +19,7 @@
 
 public class Display.NightLightView : Gtk.Grid {
     private const string SCALE_CSS = """
-        scale trough {
+        scale.night-light trough {
             background-image:
                 linear-gradient(
                     to right,
@@ -35,7 +35,7 @@ public class Display.NightLightView : Gtk.Grid {
             min-width: 5px;
         }
 
-        scale trough:disabled {
+        scale.night-light trough:disabled {
             background-image:
                 linear-gradient(
                     to bottom,
@@ -101,6 +101,7 @@ public class Display.NightLightView : Gtk.Grid {
         temp_scale.margin_top = 24;
         temp_scale.add_mark (3500, Gtk.PositionType.BOTTOM, "More Warm");
         temp_scale.add_mark (6000, Gtk.PositionType.BOTTOM, "Less Warm");
+        temp_scale.get_style_context ().add_class ("night-light");
         temp_scale.set_value (settings.get_uint ("night-light-temperature"));
 
         var content_grid = new Gtk.Grid ();

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -44,10 +44,19 @@ public class Displays.NightLightView : Granite.SimpleSettingsPage {
         schedule_button.append_text (_("Sunset to Sunrise"));
         schedule_button.append_text (_("Manual"));
 
+        var from_label = new Gtk.Label (_("From:"));
+        var from_time = new Granite.Widgets.TimePicker ();
+        var to_label = new Gtk.Label (_("To:"));
+        var to_time = new Granite.Widgets.TimePicker ();
+
         content_area.attach (temp_label, 0, 0, 1, 1);
-        content_area.attach (temp_scale, 1, 0, 1, 1);
+        content_area.attach (temp_scale, 1, 0, 4, 1);
         content_area.attach (schedule_label, 0, 1, 1, 1);
-        content_area.attach (schedule_button, 1, 1, 1, 1);
+        content_area.attach (schedule_button, 1, 1, 4, 1);
+        content_area.attach (from_label, 1, 2, 1, 1);
+        content_area.attach (from_time, 2, 2, 1, 1);
+        content_area.attach (to_label, 3, 2, 1, 1);
+        content_area.attach (to_time, 4, 2, 1, 1);
 
         var settings = new GLib.Settings ("org.gnome.settings-daemon.plugins.color");
         settings.bind ("night-light-enabled", status_switch, "active", GLib.SettingsBindFlags.DEFAULT);

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -18,6 +18,14 @@
 */
 
 public class Display.NightLightView : Gtk.Grid {
+    private Gtk.Scale temp_scale;
+
+    public int temperature {
+        set {
+            temp_scale.set_value (value);
+        }
+    }
+
     construct {
         var settings = new GLib.Settings ("org.gnome.settings-daemon.plugins.color");
 
@@ -61,7 +69,7 @@ public class Display.NightLightView : Gtk.Grid {
         temp_label.margin_top = 24;
         temp_label.xalign = 1;
 
-        var temp_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 3500, 6000, 10);
+        temp_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 3500, 6000, 10);
         temp_scale.draw_value = false;
         temp_scale.has_origin = false;
         temp_scale.inverted = true;
@@ -100,6 +108,7 @@ public class Display.NightLightView : Gtk.Grid {
         size_group.add_widget (temp_label);
 
         settings.bind ("night-light-enabled", status_switch, "active", GLib.SettingsBindFlags.DEFAULT);
+        settings.bind ("night-light-temperature", this, "temperature", GLib.SettingsBindFlags.GET);
         status_switch.bind_property ("active", content_grid, "sensitive", GLib.BindingFlags.DEFAULT);
 
         var automatic_schedule = settings.get_boolean ("night-light-schedule-automatic");

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -72,8 +72,16 @@ public class Displays.NightLightView : Granite.SimpleSettingsPage {
         schedule_button.mode_changed.connect (() => {
             if (schedule_button.selected == 0) {
                 settings.set_boolean ("night-light-schedule-automatic", true);
+                from_label.sensitive = false;
+                from_time.sensitive = false;
+                to_label.sensitive = false;
+                to_time.sensitive = false;
             } else {
                 settings.set_boolean ("night-light-schedule-automatic", false);
+                from_label.sensitive = true;
+                from_time.sensitive = true;
+                to_label.sensitive = true;
+                to_time.sensitive = true;
             }
         });
     }

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -40,7 +40,6 @@ public class Display.NightLightView : Granite.SimpleSettingsPage {
         Object (
             activatable: true,
             description: _("Night Light makes the colors of your display warmer. This may help prevent eye strain and sleeplessness."),
-            icon_name: "night-light",
             title: _("Night Light")
         );
     }

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -65,8 +65,16 @@ public class Displays.NightLightView : Granite.SimpleSettingsPage {
         var automatic_schedule = settings.get_boolean ("night-light-schedule-automatic");
         if (automatic_schedule) {
             schedule_button.selected = 0;
+            from_label.sensitive = false;
+            from_time.sensitive = false;
+            to_label.sensitive = false;
+            to_time.sensitive = false;
         } else {
             schedule_button.selected = 1;
+            from_label.sensitive = true;
+            from_time.sensitive = true;
+            to_label.sensitive = true;
+            to_time.sensitive = true;
         }
 
         schedule_button.mode_changed.connect (() => {

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -68,7 +68,7 @@ public class Display.NightLightView : Gtk.Grid {
         temp_scale.margin_top = 24;
         temp_scale.add_mark (3500, Gtk.PositionType.BOTTOM, "More Warm");
         temp_scale.add_mark (6000, Gtk.PositionType.BOTTOM, "Less Warm");
-        temp_scale.get_style_context ().add_class ("temperature");
+        temp_scale.get_style_context ().add_class ("warmth");
         temp_scale.set_value (settings.get_uint ("night-light-temperature"));
 
         var content_grid = new Gtk.Grid ();

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -18,39 +18,6 @@
 */
 
 public class Display.NightLightView : Gtk.Grid {
-    private const string SCALE_CSS = """
-        scale.night-light trough {
-            background-image:
-                linear-gradient(
-                    to right,
-                #3689e6,
-                    #f37329
-                );
-             border: none;
-            box-shadow:
-                inset 0 0 0 1px alpha (#000, 0.3),
-                inset 0 0 0 2px alpha (#000, 0.03),
-                0 1px 0 0 alpha (@bg_highlight_color, 0.3);
-            min-height: 5px;
-            min-width: 5px;
-        }
-
-        scale.night-light trough:disabled {
-            background-image:
-                linear-gradient(
-                    to bottom,
-                    alpha (
-                        #000,
-                        0.15
-                    ),
-                    alpha (
-                        #000,
-                        0.07
-                    )
-                );
-        }
-    """;
-
     construct {
         var settings = new GLib.Settings ("org.gnome.settings-daemon.plugins.color");
 
@@ -101,7 +68,7 @@ public class Display.NightLightView : Gtk.Grid {
         temp_scale.margin_top = 24;
         temp_scale.add_mark (3500, Gtk.PositionType.BOTTOM, "More Warm");
         temp_scale.add_mark (6000, Gtk.PositionType.BOTTOM, "Less Warm");
-        temp_scale.get_style_context ().add_class ("night-light");
+        temp_scale.get_style_context ().add_class ("temperature");
         temp_scale.set_value (settings.get_uint ("night-light-temperature"));
 
         var content_grid = new Gtk.Grid ();
@@ -131,15 +98,6 @@ public class Display.NightLightView : Gtk.Grid {
         size_group.add_widget (status_label);
         size_group.add_widget (schedule_label);
         size_group.add_widget (temp_label);
-
-        var provider = new Gtk.CssProvider ();
-
-        try {
-            provider.load_from_data (SCALE_CSS, SCALE_CSS.length);
-            Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-        } catch (Error e) {
-            critical (e.message);
-        }
 
         settings.bind ("night-light-enabled", status_switch, "active", GLib.SettingsBindFlags.DEFAULT);
         status_switch.bind_property ("active", content_grid, "sensitive", GLib.BindingFlags.DEFAULT);

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -37,9 +37,9 @@ public class Display.NightLightView : Gtk.Grid {
         status_switch.halign = Gtk.Align.START;
         status_switch.hexpand = true;
 
-        var description_label = new Gtk.Label (_(
-            "Night Light makes the colors of your display warmer. This may help prevent eye strain and sleeplessness."
-        ));
+        var description_label = new Gtk.Label (
+            _("Night Light makes the colors of your display warmer. This may help prevent eye strain and sleeplessness.")
+        );
         description_label.max_width_chars = 60;
         description_label.wrap = true;
         description_label.xalign = 0;
@@ -74,8 +74,8 @@ public class Display.NightLightView : Gtk.Grid {
         temp_scale.has_origin = false;
         temp_scale.inverted = true;
         temp_scale.margin_top = 24;
-        temp_scale.add_mark (3500, Gtk.PositionType.BOTTOM, "More Warm");
-        temp_scale.add_mark (6000, Gtk.PositionType.BOTTOM, "Less Warm");
+        temp_scale.add_mark (3500, Gtk.PositionType.BOTTOM, _("More Warm"));
+        temp_scale.add_mark (6000, Gtk.PositionType.BOTTOM, _("Less Warm"));
         temp_scale.get_style_context ().add_class ("warmth");
         temp_scale.set_value (settings.get_uint ("night-light-temperature"));
 
@@ -168,10 +168,6 @@ public class Display.NightLightView : Gtk.Grid {
         var minutes = (int) (dbl - hours) * 100;
 
         var date_time = new DateTime.local (1, 1, 1, hours, minutes, 0.0);
-
-        if (date_time == null) {
-            warning ("wtf why");
-        }
 
         return date_time;
     }

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -17,8 +17,55 @@
 * Boston, MA 02110-1301 USA
 */
 
-public class Displays.NightLightView : Gtk.Grid {
+public class Displays.NightLightView : Granite.SimpleSettingsPage {
+    public NightLightView () {
+        Object (
+            activatable: true,
+            description: _("Night Light makes the colors of your display warmer. This may help prevent eye strain and sleeplessness."),
+            icon_name: "night-light",
+            title: _("Night Light")
+        );
+    }
+
     construct {
-        var description_label = new Gtk.Label ();
+        var temp_label = new Gtk.Label (_("Color temperature:"));
+        temp_label.halign = Gtk.Align.END;
+
+        var temp_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 3500, 6000, 10);
+        temp_scale.draw_value = false;
+        temp_scale.inverted = true;
+        temp_scale.add_mark (3500, Gtk.PositionType.BOTTOM, "More Warm");
+        temp_scale.add_mark (6000, Gtk.PositionType.BOTTOM, "Less Warm");
+
+        var schedule_label = new Gtk.Label (_("Schedule:"));
+        schedule_label.halign = Gtk.Align.END;
+
+        var schedule_button = new Granite.Widgets.ModeButton ();
+        schedule_button.append_text (_("Sunset to Sunrise"));
+        schedule_button.append_text (_("Manual"));
+
+        content_area.attach (temp_label, 0, 0, 1, 1);
+        content_area.attach (temp_scale, 1, 0, 1, 1);
+        content_area.attach (schedule_label, 0, 1, 1, 1);
+        content_area.attach (schedule_button, 1, 1, 1, 1);
+
+        var settings = new GLib.Settings ("org.gnome.settings-daemon.plugins.color");
+        settings.bind ("night-light-enabled", status_switch, "active", GLib.SettingsBindFlags.DEFAULT);
+        settings.bind ("night-light-temperature", temp_scale, "value", GLib.SettingsBindFlags.DEFAULT);
+
+        var automatic_schedule = settings.get_boolean ("night-light-schedule-automatic");
+        if (automatic_schedule) {
+            schedule_button.selected = 0;
+        } else {
+            schedule_button.selected = 1;
+        }
+
+        schedule_button.mode_changed.connect (() => {
+            if (schedule_button.selected == 0) {
+                settings.set_boolean ("night-light-schedule-automatic", true);
+            } else {
+                settings.set_boolean ("night-light-schedule-automatic", false);
+            }
+        });
     }
 }

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -76,6 +76,8 @@ public class Display.NightLightView : Granite.SimpleSettingsPage {
         margin_top = 0;
         show_all ();
 
+        status_switch.bind_property ("active", content_area, "sensitive", GLib.BindingFlags.DEFAULT);
+
         settings.bind ("night-light-enabled", status_switch, "active", GLib.SettingsBindFlags.DEFAULT);
 
         var automatic_schedule = settings.get_boolean ("night-light-schedule-automatic");

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -102,7 +102,7 @@ public class Displays.NightLightView : Granite.SimpleSettingsPage {
         });
     }
 
-    private double date_time_double (DateTime date_time) {
+    private static double date_time_double (DateTime date_time) {
         double time_double = 0;
         time_double += date_time.get_hour ();
         time_double += date_time.get_minute () / 100;

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -75,6 +75,7 @@ public class Display.NightLightView : Gtk.Grid {
         temp_scale.inverted = true;
         temp_scale.margin_top = 24;
         temp_scale.add_mark (3500, Gtk.PositionType.BOTTOM, _("More Warm"));
+        temp_scale.add_mark (4500, Gtk.PositionType.BOTTOM, null);
         temp_scale.add_mark (6000, Gtk.PositionType.BOTTOM, _("Less Warm"));
         temp_scale.get_style_context ().add_class ("warmth");
         temp_scale.set_value (settings.get_uint ("night-light-temperature"));

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -84,5 +84,21 @@ public class Displays.NightLightView : Granite.SimpleSettingsPage {
                 to_time.sensitive = true;
             }
         });
+
+        from_time.time_changed.connect (() => {
+            settings.set_double ("night-light-schedule-from", date_time_double (from_time.time));
+        });
+
+        to_time.time_changed.connect (() => {
+            settings.set_double ("night-light-schedule-to", date_time_double (to_time.time));
+        });
+    }
+
+    private double date_time_double (DateTime date_time) {
+        double time_double = 0;
+        time_double += date_time.get_hour ();
+        time_double += date_time.get_minute () / 100;
+
+        return time_double;
     }
 }

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -18,6 +18,24 @@
 */
 
 public class Display.NightLightView : Granite.SimpleSettingsPage {
+    private const string SCALE_CSS = """
+        scale trough {
+            background-image:
+                linear-gradient(
+                    to right,
+                #3689e6,
+                    #f37329
+                );
+             border: none;
+            box-shadow:
+                inset 0 0 0 1px alpha (#000, 0.3),
+                inset 0 0 0 2px alpha (#000, 0.03),
+                0 1px 0 0 alpha (@bg_highlight_color, 0.3);
+            min-height: 5px;
+            min-width: 5px;
+        }
+    """;
+
     public NightLightView () {
         Object (
             activatable: true,
@@ -71,6 +89,15 @@ public class Display.NightLightView : Granite.SimpleSettingsPage {
         content_area.attach (to_time, 4, 1, 1, 1);
         content_area.attach (temp_label, 0, 2, 1, 1);
         content_area.attach (temp_scale, 1, 2, 4, 1);
+
+        var provider = new Gtk.CssProvider ();
+
+        try {
+            provider.load_from_data (SCALE_CSS, SCALE_CSS.length);
+            Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        } catch (Error e) {
+            critical (e.message);
+        }
 
         margin = 12;
         margin_top = 0;

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -1,0 +1,24 @@
+/*
+* Copyright (c) 2017 elementary LLC (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*/
+
+public class Displays.NightLightView : Gtk.Grid {
+    construct {
+        var description_label = new Gtk.Label ();
+    }
+}


### PR DESCRIPTION
Todo:
- [x] Only show display tags when the displays tab is open
- [x] Set up URL so we can get directly here from the future indicator

Looks like this:

![screenshot from 2017-12-12 10 28 31](https://user-images.githubusercontent.com/7277719/33901619-392182d8-df27-11e7-8f8f-a721c6f6d579.png)
