### PR TITLE
Recursive lookup of the settings

### DIFF
--- a/src/DisplayPlug.vala
+++ b/src/DisplayPlug.vala
@@ -46,7 +46,7 @@ public class Display.Plug : Switchboard.Plug {
             grid = new Gtk.Grid ();
             grid.orientation = Gtk.Orientation.VERTICAL;
 
-            var interface_settings_schema = SettingsSchemaSource.get_default ().lookup ("org.gnome.settings-daemon.plugins.color", false);
+            var interface_settings_schema = SettingsSchemaSource.get_default ().lookup ("org.gnome.settings-daemon.plugins.color", true);
             if (interface_settings_schema != null && interface_settings_schema.has_key ("night-light-enabled")) {
                 var nightlight_view = new NightLightView ();
 


### PR DESCRIPTION
For some reason, both the indicator and the plug stopped showing up on me due to the SettingsSchemaSource not finding the schema.

I've had this happen before, and setting the param to `true` fixes it 
https://valadoc.org/gio-2.0/GLib.SettingsSchemaSource.lookup.html