### PR TITLE
Fix display badge displaying when in night light view

### DIFF
--- a/src/DisplayPlug.vala
+++ b/src/DisplayPlug.vala
@@ -82,9 +82,9 @@ public class Display.Plug : Switchboard.Plug {
 
     public override void shown () {
         if (stack != null && stack.visible_child == displays_view) {
-                displays_view.displays_overlay.show_windows ();
-        } else {
             displays_view.displays_overlay.show_windows ();
+        } else {
+            displays_view.displays_overlay.hide_windows ();
         }
     }
 


### PR DESCRIPTION
Fixes #73.

Seems like someone had copied over the call to `show_windows` but forgot to actually change it to hide the badge.