### PR TITLE
Update UI when configuration changed

### DIFF
--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -8,15 +8,18 @@ msgstr ""
 "Project-Id-Version: audience\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-05-28 05:38+0400\n"
-"PO-Revision-Date: 2014-10-06 22:54+0000\n"
-"Last-Translator: alessandro <pepealex98@gmail.com>\n"
-"Language-Team: English (United Kingdom) <en_GB@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2018-04-29 14:24+0000\n"
+"Last-Translator: Ciaran Ainsworth <cda@whistlingkappa.com>\n"
+"Language-Team: English (United Kingdom) "
+"<https://weblate.elementary.io/projects/switchboard/switchboard-plug-"
+"display/en_GB/>\n"
+"Language: en_GB\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 2.18\n"
 "X-Launchpad-Export-Date: 2016-12-22 05:40+0000\n"
-"X-Generator: Launchpad (build 18298)\n"
 
 #: ../src/MirrorDisplay.vala:31 ../src/DisplayWidget.vala:101
 msgid "Resolution:"
@@ -28,7 +31,7 @@ msgstr "Configure display"
 
 #: ../src/DisplayWidget.vala:94
 msgid "Use This Display:"
-msgstr ""
+msgstr "Use This Display:"
 
 #: ../src/DisplayWidget.vala:111
 msgid "Rotation:"
@@ -52,7 +55,7 @@ msgstr "Anticlockwise"
 
 #: ../src/DisplayWidget.vala:287
 msgid "Is the primary display"
-msgstr ""
+msgstr "Is the primary display"
 
 #: ../src/DisplayWidget.vala:290
 msgid "Set as primary display"
@@ -64,7 +67,7 @@ msgstr "Displays"
 
 #: ../src/DisplayPlug.vala:33
 msgid "Configure resolution and position of monitors and projectors"
-msgstr ""
+msgstr "Configure resolution and position of monitors and projectors"
 
 #: ../src/DisplayPlug.vala:51
 msgid "Mirror Display:"

--- a/src/Objects/Monitor.vala
+++ b/src/Objects/Monitor.vala
@@ -28,6 +28,8 @@ public class Display.Monitor : GLib.Object {
     public bool is_builtin { get; set; }
     public Gee.LinkedList<Display.MonitorMode> modes { get; construct; }
 
+    public signal void modes_changed ();
+
     public Display.MonitorMode current_mode {
         owned get {
             foreach (var mode in modes) {

--- a/src/Objects/Monitor.vala
+++ b/src/Objects/Monitor.vala
@@ -55,4 +55,14 @@ public class Display.Monitor : GLib.Object {
     construct {
         modes = new Gee.LinkedList<Display.MonitorMode> ();
     }
+
+    public Display.MonitorMode? get_mode_by_id (string id) {
+        foreach (var mode in modes) {
+            if (mode.id == id) {
+                return mode;
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/Objects/MonitorManager.vala
+++ b/src/Objects/MonitorManager.vala
@@ -139,17 +139,13 @@ public class Display.MonitorManager : GLib.Object {
                 var is_preferred_variant = mutter_mode.properties.lookup ("is-preferred");
                 if (is_preferred_variant != null) {
                     mode.is_preferred = is_preferred_variant.get_boolean ();
-<<<<<<< HEAD
                 } else {
                     mode.is_preferred = false;
-=======
->>>>>>> 3a2285bc2024dfe56f303050c1a84ecbf65dd585
                 }
 
                 var is_current_variant = mutter_mode.properties.lookup ("is-current");
                 if (is_current_variant != null) {
                     mode.is_current = is_current_variant.get_boolean ();
-<<<<<<< HEAD
                 } else {
                     mode.is_current = false;
                 }
@@ -166,15 +162,6 @@ public class Display.MonitorManager : GLib.Object {
                 add_virtual_monitor (virtual_monitor);
             }
 
-=======
-                }
-                
-            }
-        }
-
-        foreach (var mutter_logical_monitor in mutter_logical_monitors) {
-            var virtual_monitor = new Display.VirtualMonitor ();
->>>>>>> 3a2285bc2024dfe56f303050c1a84ecbf65dd585
             virtual_monitor.x = mutter_logical_monitor.x;
             virtual_monitor.y = mutter_logical_monitor.y;
             virtual_monitor.scale = mutter_logical_monitor.scale;
@@ -182,21 +169,12 @@ public class Display.MonitorManager : GLib.Object {
             virtual_monitor.primary = mutter_logical_monitor.primary;
             foreach (var mutter_info in mutter_logical_monitor.monitors) {
                 foreach (var monitor in monitors) {
-<<<<<<< HEAD
                     if (compare_monitor_with_mutter_info (monitor, mutter_info) && !(monitor in virtual_monitor.monitors)) {
-=======
-                    if (compare_monitor_with_mutter_info (monitor, mutter_info)) {
->>>>>>> 3a2285bc2024dfe56f303050c1a84ecbf65dd585
                         virtual_monitor.monitors.add (monitor);
                         break;
                     }
                 }
             }
-<<<<<<< HEAD
-=======
-
-            add_virtual_monitor (virtual_monitor);
->>>>>>> 3a2285bc2024dfe56f303050c1a84ecbf65dd585
         }
     }
 

--- a/src/Objects/VirtualMonitor.vala
+++ b/src/Objects/VirtualMonitor.vala
@@ -27,7 +27,6 @@ public class Display.VirtualMonitor : GLib.Object {
     public bool primary { get; set; }
     public Gee.LinkedList<Display.Monitor> monitors { get; construct; }
 
-<<<<<<< HEAD
     // Used to distinguish two VirtualMonitors from each other.
     // We make up and ID by concatenating all serials of
     // monitors that a VirtualMonitor has.
@@ -42,8 +41,6 @@ public class Display.VirtualMonitor : GLib.Object {
         }
     }
 
-=======
->>>>>>> 3a2285bc2024dfe56f303050c1a84ecbf65dd585
     public bool is_mirror {
         get {
             return monitors.size > 1;

--- a/src/Objects/VirtualMonitor.vala
+++ b/src/Objects/VirtualMonitor.vala
@@ -27,9 +27,11 @@ public class Display.VirtualMonitor : GLib.Object {
     public bool primary { get; set; }
     public Gee.LinkedList<Display.Monitor> monitors { get; construct; }
 
-    // Used to distinguish two VirtualMonitors from each other.
-    // We make up and ID by concatenating all serials of
-    // monitors that a VirtualMonitor has.
+    /* 
+     * Used to distinguish two VirtualMonitors from each other.
+     * We make up and ID by concatenating all serials of
+     * monitors that a VirtualMonitor has.
+     */
     public string id {
         owned get {
             string val = "";

--- a/src/Objects/VirtualMonitor.vala
+++ b/src/Objects/VirtualMonitor.vala
@@ -27,6 +27,20 @@ public class Display.VirtualMonitor : GLib.Object {
     public bool primary { get; set; }
     public Gee.LinkedList<Display.Monitor> monitors { get; construct; }
 
+    // Used to distinguish two VirtualMonitors from each other.
+    // We make up and ID by concatenating all serials of
+    // monitors that a VirtualMonitor has.
+    public string id {
+        owned get {
+            string val = "";
+            foreach (var monitor in monitors) {
+                val += monitor.serial;
+            }
+
+            return val;
+        }
+    }
+
     public bool is_mirror {
         get {
             return monitors.size > 1;
@@ -58,5 +72,15 @@ public class Display.VirtualMonitor : GLib.Object {
 
     construct {
         monitors = new Gee.LinkedList<Display.Monitor> ();
+    } 
+
+    public void get_current_mode_size (out int width, out int height) {
+        if (!is_active) {
+            width = 1280;
+            height = 720;
+        } else {
+            width = monitor.current_mode.width;
+            height = monitor.current_mode.height;
+        }
     }
 }

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -188,7 +188,6 @@ public class Display.DisplayWidget : Gtk.EventBox {
             get_style_context ().add_class ("disabled");
         }
 
-        bool rotation_set = false;
         resolution_combobox.changed.connect (() => {
             Value val;
             Gtk.TreeIter iter;
@@ -197,15 +196,13 @@ public class Display.DisplayWidget : Gtk.EventBox {
             set_geometry (real_x, real_y, (int)((Display.MonitorMode) val).width, (int)((Display.MonitorMode) val).height);
             virtual_monitor.monitor.current_mode.is_current = false;
             ((Display.MonitorMode)val).is_current = true;
-            rotation_set = false;
             rotation_combobox.set_active (0);
-            rotation_set = true;
             configuration_changed ();
             check_position ();
         });
 
         rotation_combobox.changed.connect (() => {
-            /*Value val;
+            Value val;
             Gtk.TreeIter iter;
             rotation_combobox.get_active_iter (out iter);
             rotation_list_store.get_value (iter, 1, out val);
@@ -230,9 +227,8 @@ public class Display.DisplayWidget : Gtk.EventBox {
                     virtual_monitor.get_current_mode_size (out real_width, out real_height);
                     label.angle = 0;
                     break;
-            }*/
+            }
 
-            //rotation_set = true;
             configuration_changed ();
             check_position ();
         });

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -190,6 +190,8 @@ public class Display.DisplayWidget : Gtk.EventBox {
             resolution_combobox.get_active_iter (out iter);
             resolution_list_store.get_value (iter, 1, out val);
             set_geometry (real_x, real_y, (int)((Display.MonitorMode) val).width, (int)((Display.MonitorMode) val).height);
+            virtual_monitor.monitor.current_mode.is_current = false;
+            ((Display.MonitorMode)val).is_current = true;
             rotation_set = false;
             rotation_combobox.set_active (0);
             rotation_set = true;
@@ -371,7 +373,6 @@ public class Display.DisplayWidget : Gtk.EventBox {
         real_y = y;
         real_width = width;
         real_height = height;
-        //output_info.set_geometry (real_x, real_y, real_width, real_height);
     }
 
     public bool equals (DisplayWidget sibling) {

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -233,40 +233,40 @@ public class Display.DisplayWidget : Gtk.EventBox {
             check_position ();
         });
 
-        //  Gtk.TreeIter iter;
+        /*Gtk.TreeIter iter;
 
-        //  rotation_list_store.append (out iter);
-        //  rotation_list_store.set (iter, 0, _("None"), 1, DisplayTransform.ROTATION_0);
+        rotation_list_store.append (out iter);
+        rotation_list_store.set (iter, 0, _("None"), 1, DisplayTransform.ROTATION_0);
 
-        //  if (output_info.supports_rotation (DisplayTransform.ROTATION_90)) {
-        //      rotation_list_store.append (out iter);
-        //      rotation_list_store.set (iter, 0, _("Clockwise"), 1, DisplayTransform.ROTATION_90);
-        //      if (output_info.get_rotation () == DisplayTransform.ROTATION_90) {
-        //          rotation_combobox.set_active_iter (iter);
-        //          label.angle = 270;
-        //          rotation_set = true;
-        //      }
-        //  }
+        if (output_info.supports_rotation (DisplayTransform.ROTATION_90)) {
+            rotation_list_store.append (out iter);
+            rotation_list_store.set (iter, 0, _("Clockwise"), 1, DisplayTransform.ROTATION_90);
+            if (output_info.get_rotation () == DisplayTransform.ROTATION_90) {
+                rotation_combobox.set_active_iter (iter);
+                label.angle = 270;
+                rotation_set = true;
+            }
+        }
 
-        //  if (output_info.supports_rotation (DisplayTransform.ROTATION_180)) {
-        //      rotation_list_store.append (out iter);
-        //      rotation_list_store.set (iter, 0, _("Flipped"), 1, DisplayTransform.ROTATION_180);
-        //      if (output_info.get_rotation () == DisplayTransform.ROTATION_180) {
-        //          rotation_combobox.set_active_iter (iter);
-        //          label.angle = 180;
-        //          rotation_set = true;
-        //      }
-        //  }
+        if (output_info.supports_rotation (DisplayTransform.ROTATION_180)) {
+            rotation_list_store.append (out iter);
+            rotation_list_store.set (iter, 0, _("Flipped"), 1, DisplayTransform.ROTATION_180);
+            if (output_info.get_rotation () == DisplayTransform.ROTATION_180) {
+                rotation_combobox.set_active_iter (iter);
+                label.angle = 180;
+                rotation_set = true;
+            }
+        }
 
-        //  if (output_info.supports_rotation (DisplayTransform.ROTATION_270)) {
-        //      rotation_list_store.append (out iter);
-        //      rotation_list_store.set (iter, 0, _("Counterclockwise"), 1, DisplayTransform.ROTATION_270);
-        //      if (output_info.get_rotation () == DisplayTransform.ROTATION_270) {
-        //          rotation_combobox.set_active_iter (iter);
-        //          label.angle = 90;
-        //          rotation_set = true;
-        //      }
-        //  }
+        if (output_info.supports_rotation (DisplayTransform.ROTATION_270)) {
+            rotation_list_store.append (out iter);
+            rotation_list_store.set (iter, 0, _("Counterclockwise"), 1, DisplayTransform.ROTATION_270);
+            if (output_info.get_rotation () == DisplayTransform.ROTATION_270) {
+                rotation_combobox.set_active_iter (iter);
+                label.angle = 90;
+                rotation_set = true;
+            }
+        }*/
 
         rotation_combobox.set_active (0);
         on_vm_transform_changed ();


### PR DESCRIPTION
* Update resolution when we receive a signal that the current state changed (e.g clicking the "Restore previous setting" in the "Revert resolution dialog")
* Make rotation UI work
* Update rotation UI when it changes
* Simplify updating display view when rotation changes
* Move some core functions to `VirtualMonitor`
* Add an `id` property to `VirtualMonitor` to enable `MonitorManager` to update existing virtual monitors when state changes