### PR TITLE
Fixes crash with multidisplay

### DIFF
--- a/src/Interfaces/MutterDisplayConfig.vala
+++ b/src/Interfaces/MutterDisplayConfig.vala
@@ -79,6 +79,11 @@ public struct MutterReadMonitorInfo {
     public string vendor;
     public string product;
     public string serial;
+    public uint hash {
+        get {
+            return (connector+vendor+product+serial).hash ();
+        }
+    }
 }
 
 public struct MutterReadMonitorMode {

--- a/src/Objects/Monitor.vala
+++ b/src/Objects/Monitor.vala
@@ -24,6 +24,12 @@ public class Display.Monitor : GLib.Object {
     public string vendor { get; set; }
     public string product { get; set; }
     public string serial { get; set; }
+    public uint hash {
+        get {
+            return (connector+vendor+product+serial).hash ();
+        }
+    }
+    
     public string display_name { get; set; }
     public bool is_builtin { get; set; }
     public Gee.LinkedList<Display.MonitorMode> modes { get; construct; }

--- a/src/Objects/MonitorManager.vala
+++ b/src/Objects/MonitorManager.vala
@@ -176,7 +176,7 @@ public class Display.MonitorManager : GLib.Object {
         }
 
         foreach (var mutter_logical_monitor in mutter_logical_monitors) {
-            string monitors_id = generate_id_from_monitors (mutter_logical_monitor.monitors);
+            string monitors_id = VirtualMonitor.generate_id_from_monitors (mutter_logical_monitor.monitors);
             var virtual_monitor = get_virtual_monitor_by_id (monitors_id);
             if (virtual_monitor == null) {
                 virtual_monitor = new VirtualMonitor ();
@@ -345,15 +345,6 @@ public class Display.MonitorManager : GLib.Object {
         }
 
         return null;
-    }
-
-    private static string generate_id_from_monitors (MutterReadMonitorInfo[] infos) {
-        string val = "";
-        foreach (var info in infos) {
-            val += info.serial;
-        }
-
-        return val;
     }
 
     private static bool compare_monitor_with_mutter_info (Display.Monitor monitor, MutterReadMonitorInfo mutter_info) {

--- a/src/Objects/MonitorManager.vala
+++ b/src/Objects/MonitorManager.vala
@@ -117,7 +117,7 @@ public class Display.MonitorManager : GLib.Object {
 
         var monitors_with_changed_modes = new Gee.LinkedList<Display.Monitor> ();
         foreach (var mutter_monitor in mutter_monitors) {
-            var monitor = get_monitor_by_serial (mutter_monitor.monitor.serial);
+            var monitor = get_monitor_by_hash (mutter_monitor.monitor.hash);
             if (monitor == null) {
                 monitor = new Display.Monitor ();
                 monitors.add (monitor);
@@ -366,6 +366,16 @@ public class Display.MonitorManager : GLib.Object {
     private Display.Monitor? get_monitor_by_serial (string serial) {
         foreach (var monitor in monitors) {
             if (monitor.serial == serial) {
+                return monitor;
+            }
+        }
+
+        return null;
+    }
+    
+    private Display.Monitor? get_monitor_by_hash (uint hash) {
+        foreach (var monitor in monitors) {
+            if (monitor.hash == hash) {
                 return monitor;
             }
         }

--- a/src/Objects/MonitorManager.vala
+++ b/src/Objects/MonitorManager.vala
@@ -354,16 +354,6 @@ public class Display.MonitorManager : GLib.Object {
                && monitor.serial == mutter_info.serial;
     }
 
-    private Display.Monitor? get_monitor_by_serial (string serial) {
-        foreach (var monitor in monitors) {
-            if (monitor.serial == serial) {
-                return monitor;
-            }
-        }
-
-        return null;
-    }
-    
     private Display.Monitor? get_monitor_by_hash (uint hash) {
         foreach (var monitor in monitors) {
             if (monitor.hash == hash) {

--- a/src/Objects/VirtualMonitor.vala
+++ b/src/Objects/VirtualMonitor.vala
@@ -143,7 +143,6 @@ public class Display.VirtualMonitor : GLib.Object {
             val += info.hash;
         }
 
-        print (@"$val\n");
         return val.to_string ();
     }
 }

--- a/src/Objects/VirtualMonitor.vala
+++ b/src/Objects/VirtualMonitor.vala
@@ -31,17 +31,17 @@ public class Display.VirtualMonitor : GLib.Object {
 
     /* 
      * Used to distinguish two VirtualMonitors from each other.
-     * We make up and ID by concatenating all serials of
+     * We make up and ID by sum all hashes of
      * monitors that a VirtualMonitor has.
      */
     public string id {
         owned get {
-            string val = "";
+            uint val = 0;
             foreach (var monitor in monitors) {
-                val += monitor.serial;
+                val += monitor.hash;
             }
 
-            return val;
+            return val.to_string ();
         }
     }
 
@@ -135,5 +135,15 @@ public class Display.VirtualMonitor : GLib.Object {
                 mode.is_current = mode == current_mode;
             }
         }
+    }
+
+    public static string generate_id_from_monitors (MutterReadMonitorInfo[] infos) {
+        uint val = 0;
+        foreach (var info in infos) {
+            val += info.hash;
+        }
+
+        print (@"$val\n");
+        return val.to_string ();
     }
 }


### PR DESCRIPTION
Sending another PR because the first was bundled with my another PR, explaining, some displays are being equal so I made a hash that joins connector, serial, display name and vendor.