### PR TITLE
Tweak display colors

### DIFF
--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -35,7 +35,9 @@ public class Display.DisplayWidget : Gtk.EventBox {
     private double start_x = 0;
     private double start_y = 0;
     private bool holding = false;
-    private Gtk.Button primary_image;
+
+    public Gtk.Button primary_image { get; private set; }
+    public Gtk.ToggleButton toggle_settings { get; private set; }
 
     private Gtk.ComboBox resolution_combobox;
     private Gtk.ListStore resolution_list_store;
@@ -88,7 +90,7 @@ public class Display.DisplayWidget : Gtk.EventBox {
         primary_image.clicked.connect (() => set_as_primary ());
         set_primary (virtual_monitor.primary);
 
-        var toggle_settings = new Gtk.ToggleButton ();
+        toggle_settings = new Gtk.ToggleButton ();
         toggle_settings.margin = 6;
         toggle_settings.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         toggle_settings.halign = Gtk.Align.END;

--- a/src/Widgets/DisplaysOverlay.vala
+++ b/src/Widgets/DisplaysOverlay.vala
@@ -40,29 +40,60 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
         "@BANANA_100",
         "@LIME_100",
         "@GRAPE_100",
-        "@COCOA_100",
-        "@SLATE_100",
+        "@COCOA_100"
     };
-    private static string[] border_colors = {
-        "@BLUEBERRY_500",
-        "@STRAWBERRY_500",
-        "@ORANGE_500",
-        "@BANANA_500",
-        "@LIME_500",
-        "@GRAPE_500",
-        "@COCOA_500",
-        "@SLATE_500",
+    private static string[] text_colors = {
+        "@BLUEBERRY_900",
+        "@STRAWBERRY_900",
+        "@ORANGE_900",
+        "@BANANA_900",
+        "@LIME_900",
+        "@GRAPE_900",
+        "@COCOA_900"
     };
 
     const string COLORED_STYLE_CSS = """
+        @define-color BG_COLOR %s;
+        @define-color TEXT_COLOR %s;
+
         .colored {
-            background-color: %s;
-            border: 1px %s solid;
-            color: %s;
+            background-color: @BG_COLOR;
+            color: @TEXT_COLOR;
+            text-shadow: 0 1px 1px alpha (#fff, 0.1);
+            -gtk-icon-shadow: 0 1px 1px alpha (#fff, 0.1);
+            -gtk-icon-palette: warning #fff;
+        }
+
+        widget.colored {
+            border: 1px solid mix (@BG_COLOR, @TEXT_COLOR, 0.3);
+        }
+
+        .colored button {
+            border-radius: 50%;
+            padding: 6px;
+        }
+
+        .colored button:focus {
+            background: alpha (@TEXT_COLOR, 0.25);
+        }
+
+        .colored button:checked {
+            background: alpha (@TEXT_COLOR, 0.5);
+            border-color: transparent;
         }
 
         .colored.disabled {
-            background-color: #aaa;
+            background-color: @SLATE_100;
+            color: @SLATE_700;
+        }
+
+        .colored.disabled button:focus {
+            background: alpha (@SLATE_700, 0.25);
+        }
+
+        .colored.disabled button:checked {
+            background: alpha (@TEXT_COLOR, 0.5);
+            border-color: transparent;
         }
     """;
 
@@ -190,18 +221,23 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
         var provider = new Gtk.CssProvider ();
         try {
             var color_number = (get_children ().length ()-2)%7;
-            //  var font_color = "#ffffff";
-            //  if (color_number == 3 || color_number == 4) {
-            //      font_color = "#333333";
-            //  }
-            var font_color = "@BLACK_500";
 
-            var colored_css = COLORED_STYLE_CSS.printf (colors[color_number], border_colors[color_number], font_color);
+            var colored_css = COLORED_STYLE_CSS.printf (colors[color_number], text_colors[color_number]);
             provider.load_from_data (colored_css, colored_css.length);
+
             var context = display_widget.get_style_context ();
             context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
             context.add_class ("colored");
+
             context = display_widget.display_window.get_style_context ();
+            context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+            context.add_class ("colored");
+
+            context = display_widget.primary_image.get_style_context ();
+            context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+            context.add_class ("colored");
+
+            context = display_widget.toggle_settings.get_style_context ();
             context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
             context.add_class ("colored");
         } catch (GLib.Error e) {

--- a/src/Widgets/DisplaysOverlay.vala
+++ b/src/Widgets/DisplaysOverlay.vala
@@ -33,11 +33,31 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
 
     private unowned Display.MonitorManager monitor_manager;
     public int active_displays { get; set; default = 0; }
-    private static string[] colors = {"#3892e0", "#da4d45", "#f37329", "#fbd25d", "#93d844", "#8a4ebf", "#333333"};
+    private static string[] colors = {
+        "@BLUEBERRY_100",
+        "@STRAWBERRY_100",
+        "@ORANGE_100",
+        "@BANANA_100",
+        "@LIME_100",
+        "@GRAPE_100",
+        "@COCOA_100",
+        "@SLATE_100",
+    };
+    private static string[] border_colors = {
+        "@BLUEBERRY_500",
+        "@STRAWBERRY_500",
+        "@ORANGE_500",
+        "@BANANA_500",
+        "@LIME_500",
+        "@GRAPE_500",
+        "@COCOA_500",
+        "@SLATE_500",
+    };
 
     const string COLORED_STYLE_CSS = """
         .colored {
             background-color: %s;
+            border: 1px %s solid;
             color: %s;
         }
 
@@ -170,12 +190,13 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
         var provider = new Gtk.CssProvider ();
         try {
             var color_number = (get_children ().length ()-2)%7;
-            var font_color = "#ffffff";
-            if (color_number == 3 || color_number == 4) {
-                font_color = "#333333";
-            }
+            //  var font_color = "#ffffff";
+            //  if (color_number == 3 || color_number == 4) {
+            //      font_color = "#333333";
+            //  }
+            var font_color = "@BLACK_500";
 
-            var colored_css = COLORED_STYLE_CSS.printf (colors[color_number], font_color);
+            var colored_css = COLORED_STYLE_CSS.printf (colors[color_number], border_colors[color_number], font_color);
             provider.load_from_data (colored_css, colored_css.length);
             var context = display_widget.get_style_context ();
             context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);


### PR DESCRIPTION
See: #156 

Used 100 variants of official palette to make it easier on the eye. Added a border with the 500 variant.
https://elementary.io/docs/human-interface-guidelines#color

Examples:
![screenshot from 2019-03-04 18-38-49 2x](https://user-images.githubusercontent.com/523210/53751542-c57b4d00-3eac-11e9-9a89-7746114d9195.png)
![screenshot from 2019-03-04 18-28-30](https://user-images.githubusercontent.com/523210/53751445-91a02780-3eac-11e9-8010-fb7946ebc489.png)
![screenshot from 2019-03-04 18-31-05](https://user-images.githubusercontent.com/523210/53751457-96fd7200-3eac-11e9-94e5-687c67e0b6d7.png)
![screenshot from 2019-03-04 18-31-39](https://user-images.githubusercontent.com/523210/53751463-9a90f900-3eac-11e9-8acd-a53b25d55d3e.png)
![screenshot from 2019-03-04 18-32-23](https://user-images.githubusercontent.com/523210/53751472-9c5abc80-3eac-11e9-9998-92e8c9441426.png)
