### PR TITLE
Fix multiple issues

### DIFF
--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -329,8 +329,8 @@ public class Display.DisplayWidget : Gtk.EventBox {
 
     string update_geometry_label () {
         return @"x: $(virtual_monitor.x + delta_x) y: $(virtual_monitor.y + delta_y) w: $real_width h: $real_height";
-
     }
+
     private void populate_refresh_rates () {
         refresh_list_store.clear ();
 

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -35,9 +35,9 @@ public class Display.DisplayWidget : Gtk.EventBox {
     public int last_valid_delta_x { get; set; default = 0; }
     public int last_valid_delta_y { get; set; default = 0; }
     public bool only_display { get; set; default = false; }
+    public bool holding = false;
     private double start_x = 0;
     private double start_y = 0;
-    private bool holding = false;
 
     public Gtk.Button primary_image { get; private set; }
     public Gtk.MenuButton toggle_settings { get; private set; }
@@ -330,7 +330,6 @@ public class Display.DisplayWidget : Gtk.EventBox {
     }
 
     string update_geometry_label () {
-        debug (@"x: $(virtual_monitor.x + delta_x), y: $(virtual_monitor.y + delta_y), w: $real_width, h: $real_height");
         return @"x: $(virtual_monitor.x + delta_x) y: $(virtual_monitor.y + delta_y) w: $real_width h: $real_height";
 
     }
@@ -423,6 +422,7 @@ public class Display.DisplayWidget : Gtk.EventBox {
         if (only_display) {
             return false;
         }
+        debug ("delta_x %d, delta_y %d", delta_x, delta_y);
 
         start_x = event.x_root;
         start_y = event.y_root;

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -21,7 +21,7 @@
 
 public class Display.DisplayWidget : Gtk.EventBox {
     public signal void set_as_primary ();
-    public signal void move_display (double diff_x, double diff_y, bool align_widgets);
+    public signal void move_display (double diff_x, double diff_y, Gdk.EventMotion event);
     public signal void end_grab (int delta_x, int delta_y);
     public signal void check_position ();
     public signal void configuration_changed ();
@@ -443,8 +443,7 @@ public class Display.DisplayWidget : Gtk.EventBox {
 
     public override bool motion_notify_event (Gdk.EventMotion event) {
         if (holding && !only_display) {
-            var align_widgets = !(Gdk.ModifierType.CONTROL_MASK in event.state);
-            move_display (event.x_root - start_x, event.y_root - start_y, align_widgets);
+            move_display (event.x_root - start_x, event.y_root - start_y, event);
             geometry_label.label = update_geometry_label ();
         }
 

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -49,8 +49,6 @@ public class Display.DisplayWidget : Gtk.EventBox {
     private Gtk.ComboBox refresh_combobox;
     private Gtk.ListStore refresh_list_store;
 
-    Gtk.Label geometry_label;
-
     private int real_width = 0;
     private int real_height = 0;
 
@@ -98,10 +96,6 @@ public class Display.DisplayWidget : Gtk.EventBox {
         label.halign = Gtk.Align.CENTER;
         label.valign = Gtk.Align.CENTER;
         label.expand = true;
-        geometry_label = new Gtk.Label (update_geometry_label ());
-        geometry_label.halign = Gtk.Align.CENTER;
-        geometry_label.valign = Gtk.Align.CENTER;
-        geometry_label.expand = true;
 
         var use_label = new Gtk.Label (_("Use This Display:"));
         use_label.halign = Gtk.Align.END;
@@ -202,8 +196,7 @@ public class Display.DisplayWidget : Gtk.EventBox {
         var grid = new Gtk.Grid ();
         grid.attach (primary_image, 0, 0);
         grid.attach (toggle_settings, 2, 0);
-        grid.attach (label, 0, 1, 3, 2);
-        grid.attach (geometry_label, 0, 3, 3, 1);
+        grid.attach (label, 0, 0, 3, 2);
 
         add (grid);
 
@@ -327,10 +320,6 @@ public class Display.DisplayWidget : Gtk.EventBox {
         check_position ();
     }
 
-    string update_geometry_label () {
-        return @"x: $(virtual_monitor.x + delta_x) y: $(virtual_monitor.y + delta_y) w: $real_width h: $real_height";
-    }
-
     private void populate_refresh_rates () {
         refresh_list_store.clear ();
 
@@ -444,7 +433,7 @@ public class Display.DisplayWidget : Gtk.EventBox {
     public override bool motion_notify_event (Gdk.EventMotion event) {
         if (holding && !only_display) {
             move_display (event.x_root - start_x, event.y_root - start_y, event);
-            geometry_label.label = update_geometry_label ();
+            queue_resize_no_redraw ();
         }
 
         return false;
@@ -482,7 +471,6 @@ public class Display.DisplayWidget : Gtk.EventBox {
         virtual_monitor.y = y;
         real_width = width;
         real_height = height;
-        geometry_label.label = update_geometry_label ();
     }
 
     public bool equals (DisplayWidget sibling) {

--- a/src/Widgets/DisplaysOverlay.vala
+++ b/src/Widgets/DisplaysOverlay.vala
@@ -517,7 +517,7 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
 
         // I) Try to snap to edge
         Gdk.Rectangle anchor_rect, intersection;
-        Gdk.Rectangle test_rects[4]; 
+        Gdk.Rectangle test_rects[4];
         test_rects [0] = { 0, widget_y, widget_x, widget_height }; // area to left of the widget
         test_rects [1] = { widget_x + widget_width, widget_y, int.MAX - (widget_x + widget_width + 1), widget_height }; // area to right of the widget
         test_rects [2] = { widget_x, 0, widget_width, widget_y }; // area at the top of the widget

--- a/src/Widgets/DisplaysOverlay.vala
+++ b/src/Widgets/DisplaysOverlay.vala
@@ -286,11 +286,11 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
     }
 
     private void align_edges (DisplayWidget display_widget) {
-        int widget_x, widget_y, widget_width, widget_height; 
+        int widget_x, widget_y, widget_width, widget_height;
         display_widget.get_geometry (out widget_x, out widget_y, out widget_width, out widget_height);
 
         int anchor_points[6];
-        int widget_points[6]; 
+        int widget_points[6];
         widget_points [0] = widget_x;
         widget_points [1] = widget_x + widget_width / 2 - 1;
         widget_points [2] = widget_x + widget_width - 1;
@@ -307,7 +307,7 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
             if (child is DisplayWidget && child != display_widget) {
                 var anchor = (DisplayWidget) child;
 
-                int x, y, width, height; 
+                int x, y, width, height;
                 anchor.get_geometry (out x, out y, out width, out height);
                 anchor_points [0] = x;
                 anchor_points [1] = x + width / 2 - 1;
@@ -336,7 +336,7 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
                 }
             }
         }
-        
+
         if (aligned [0]) {
             display_widget.delta_x = aligned_delta [0];
         }
@@ -360,7 +360,7 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
         }
     }
 
-    // to check if a display_widget is connected (has no gaps) one can check if 
+    // to check if a display_widget is connected (has no gaps) one can check if
     // a 1px larger rectangle intersects with any of other display_widgets
     private bool is_connected (DisplayWidget display_widget, List<DisplayWidget> other_display_widgets) {
         int x, y, width, height;
@@ -485,18 +485,18 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
 
     /**
      * Widget snaping is done by trying to snap the current widget to other widgets called anchors.
-     * 
-     * I) At first it is checked if it is possible to snap a widget using only horizontal or 
-     * only veritcal translation. This condition can checked be calculating the intersection of 
+     *
+     * I) At first it is checked if it is possible to snap a widget using only horizontal or
+     * only veritcal translation. This condition can checked be calculating the intersection of
      * a test_rect and the current anchor_rect. If the two rectangles intersect the the distance
      * to the closest edge gets calculated. Afterwards the widgets snaps to the closest anchor.
-     * 
+     *
      * Cases:           W = widget, A = current anchor
-     * 
+     *
      *   0.        1.        2.        3.
      *     A W       W A        W         A
      *                          A         W
-     * 
+     *
      * II) If it is not possible to snap the widget horizontally or vertically to any edge,
      * the widget is snaped diagonally to the nearest corner.
      */
@@ -508,8 +508,8 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
 
         int widget_x, widget_y, widget_width, widget_height;
         widget.get_geometry (out widget_x, out widget_y, out widget_width, out widget_height);
-        widget_x += widget.delta_x; 
-        widget_y += widget.delta_y; 
+        widget_x += widget.delta_x;
+        widget_y += widget.delta_y;
 
         int distance = int.MAX;
         int test_distance;

--- a/src/Widgets/DisplaysOverlay.vala
+++ b/src/Widgets/DisplaysOverlay.vala
@@ -486,11 +486,11 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
 
     /**
      * Widget snaping is done by trying to snap the current widget to other widgets called anchors.
-     *
      * I) At first it is checked if it is possible to snap a widget using only horizontal or
-     * only veritcal translation. This condition can checked be calculating the intersection of
-     * a test_rect and the current anchor_rect. If the two rectangles intersect the the distance
-     * to the closest edge gets calculated. Afterwards the widgets snaps to the closest anchor.
+     * only veritcal translation. This can be done by using four different test_rects which occupy
+     * the area to the left, to the right, at the top and at the bottom of the widget, respectively.
+     * If a test_rect intersects with one of the other anchor_rects the distance to the closest edge
+     * of the anchor get calculated. Afterwards the widgets snaps to the closest anchor.
      *
      * Cases:           W = widget, A = current anchor
      *
@@ -499,7 +499,7 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
      *                          A         W
      *
      * II) If it is not possible to snap the widget horizontally or vertically to any edge,
-     * the widget is snaped diagonally to the nearest corner.
+     * the widget is snaped diagonally to the nearest corner of an anchor.
      */
 
     private void snap_widget (Display.DisplayWidget widget, List<Display.DisplayWidget> anchors) {
@@ -603,7 +603,6 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
             }
         }
 
-        // Snap widget
         if (widget.holding) {
             widget.delta_x += distance_x;
             widget.delta_y += distance_y;

--- a/src/Widgets/DisplaysOverlay.vala
+++ b/src/Widgets/DisplaysOverlay.vala
@@ -400,7 +400,7 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
         });
 
         if (min_x == 0 && min_y == 0)
-          return;
+            return;
 
         get_children ().foreach ((child) => {
             if (child is DisplayWidget) {
@@ -513,15 +513,15 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
 
         int distance = int.MAX;
         int test_distance;
-        var snap_mode = -1; // -1: could not snap to edge, 0: snap left, 1: snap right, 2: snap top, 3: snap bottom
+        var snap_mode = -1; // -1: snap to corner, 0: snap left, 1: snap right, 2: snap top, 3: snap bottom
 
-        // I) Try to snap to edge horizontally or vertically
+        // I) Try to snap to edge
         Gdk.Rectangle anchor_rect, intersection;
-        Gdk.Rectangle test_rects[4];
-        test_rects [0] = {0, widget_y, widget_x, widget_height};
-        test_rects [1] = {widget_x + widget_width, widget_y, int.MAX - (widget_x + widget_width + 1), widget_height};
-        test_rects [2] = {widget_x, 0, widget_width, widget_y};
-        test_rects [3] = {widget_x, widget_y + widget_height, widget_width, int.MAX - (widget_y + widget_height + 1)};
+        Gdk.Rectangle test_rects[4]; 
+        test_rects [0] = { 0, widget_y, widget_x, widget_height }; // area to left of the widget
+        test_rects [1] = { widget_x + widget_width, widget_y, int.MAX - (widget_x + widget_width + 1), widget_height }; // area to right of the widget
+        test_rects [2] = { widget_x, 0, widget_width, widget_y }; // area at the top of the widget
+        test_rects [3] = { widget_x, widget_y + widget_height, widget_width, int.MAX - (widget_y + widget_height + 1) }; // area at the bottom the widget
 
         foreach (var anchor in anchors) {
             int anchor_x, anchor_y, anchor_width, anchor_height;
@@ -533,16 +533,16 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
                 if (test_rects [i].intersect (anchor_rect, out intersection)) {
                     switch (i) {
                         case 0: // ... left
-                            test_distance = intersection.x + intersection.width - widget_x;
+                            test_distance = intersection.x - widget_x + intersection.width;
                             break;
                         case 1: // ... right
-                            test_distance = intersection.x - 1 - (widget_x + widget_width - 1);
+                            test_distance = intersection.x - widget_x - widget_width;
                             break;
                         case 2: // ... top
-                            test_distance = intersection.y + intersection.height - widget_y;
+                            test_distance = intersection.y - widget_y + intersection.height;
                             break;
                         default: // ... bottom
-                            test_distance = intersection.y - 1 - (widget_y + widget_height - 1);
+                            test_distance = intersection.y - widget_y - widget_height;
                             break;
                     }
 

--- a/src/Widgets/DisplaysOverlay.vala
+++ b/src/Widgets/DisplaysOverlay.vala
@@ -283,6 +283,8 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
         if ((Gdk.ModifierType.SHIFT_MASK in event.state)) {
             snap_edges (display_widget);
         }
+
+        display_widget.queue_resize_no_redraw ();
     }
 
     private void align_edges (DisplayWidget display_widget) {

--- a/src/Widgets/DisplaysOverlay.vala
+++ b/src/Widgets/DisplaysOverlay.vala
@@ -446,14 +446,11 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
                     distances [2] = src_y - y - height;
                     distances [3] = src_y - y + src_height;
 
+                    // if distance to upper egde == distance lower edge, move horizontally
+                    int end_i = distances [2] == -distances [3] ? 2 : 4;
                     int best_i = 0;
-                    for (var i = 1; i < 4; i++) {
+                    for (var i = 1; i < end_i; i++) {
                         if (distances [i].abs () < distances [best_i].abs ()) {
-                            if (distances [i].abs () == distances [i + 1].abs ()) {
-                                i++;
-                                continue;
-                            }
-
                             best_i = i;
                         }
                     }

--- a/src/Widgets/DisplaysOverlay.vala
+++ b/src/Widgets/DisplaysOverlay.vala
@@ -216,6 +216,7 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
         display_widget.check_position.connect (() => {
             check_intersects (display_widget);
             close_gaps ();
+            display_widget.queue_resize_no_redraw ();
         });
         display_widget.move_display.connect ((diff_x, diff_y, event) => move_display (display_widget, diff_x, diff_y, event));
         display_widget.configuration_changed.connect (() => check_configuration_changed ());

--- a/src/Widgets/DisplaysOverlay.vala
+++ b/src/Widgets/DisplaysOverlay.vala
@@ -289,19 +289,17 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
         int widget_x, widget_y, widget_width, widget_height;
         display_widget.get_geometry (out widget_x, out widget_y, out widget_width, out widget_height);
 
-        int anchor_points[6];
         int widget_points[6];
-        widget_points [0] = widget_x;
-        widget_points [1] = widget_x + widget_width / 2 - 1;
-        widget_points [2] = widget_x + widget_width - 1;
-        widget_points [3] = widget_y;
-        widget_points [4] = widget_y + widget_height / 2 - 1;
-        widget_points [5] = widget_y + widget_height - 1;
+        widget_points [0] = widget_x;                           // x_start
+        widget_points [1] = widget_x + widget_width / 2 - 1;    // x_center
+        widget_points [2] = widget_x + widget_width - 1;        // x_end
+        widget_points [3] = widget_y;                           // y_start
+        widget_points [4] = widget_y + widget_height / 2 - 1;   // y_center
+        widget_points [5] = widget_y + widget_height - 1;       // y_end
 
         bool aligned[2] = { false, false };
         int aligned_delta[2] = { int.MAX, int.MAX };
         int current_delta[2] = { display_widget.delta_x, display_widget.delta_y };
-        var threshold = int.min ( widget_width / 10, widget_height / 10 );
 
         foreach (var child in get_children ()) {
             if (child is DisplayWidget && child != display_widget) {
@@ -309,14 +307,17 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
 
                 int x, y, width, height;
                 anchor.get_geometry (out x, out y, out width, out height);
-                anchor_points [0] = x;
-                anchor_points [1] = x + width / 2 - 1;
-                anchor_points [2] = x + width - 1;
-                anchor_points [3] = y;
-                anchor_points [4] = y + height / 2 - 1;
-                anchor_points [5] = y + height - 1;
 
-                for (var u = 0; u < 2; u++) {
+                int anchor_points[6];
+                anchor_points [0] = x;                          // x_start
+                anchor_points [1] = x + width / 2 - 1;          // x_center
+                anchor_points [2] = x + width - 1;              // x_end
+                anchor_points [3] = y;                          // y_start
+                anchor_points [4] = y + height / 2 - 1;         // y_center
+                anchor_points [5] = y + height - 1;             // y_end
+
+                int threshold = int.min (width, height) / 10;
+                for (var u = 0; u < 2; u++) { // 0: X, 1: Y
                     for (var i = 0; i < 3; i++) {
                         for (var j = 0; j < 3; j++) {
                             int test_delta = anchor_points [i + 3 * u] - widget_points [j + 3 * u];
@@ -351,7 +352,7 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
             if (child is DisplayWidget) {
                 display_widgets.append ((DisplayWidget) child);
             }
-        } 
+        }
 
         foreach (var display_widget in display_widgets) {
             if (!is_connected (display_widget, display_widgets)) {

--- a/src/Widgets/DisplaysOverlay.vala
+++ b/src/Widgets/DisplaysOverlay.vala
@@ -240,8 +240,8 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
             display_widget.set_geometry (delta_x + x, delta_y + y, width, height);
             display_widget.queue_resize_no_redraw ();
             check_configuration_changed ();
-            snap_edges (display_widget);
             check_intersects (display_widget);
+            snap_edges (display_widget);
             close_gaps ();
             verify_global_positions ();
             calculate_ratio ();
@@ -444,7 +444,7 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
                     if (src_rect.intersect (test_rect, out intersection)) {
                         var distance_x = 0;
                         var distance_y = 0;
-                        if ((intersection.width < intersection.height || intersection.height == src_height) && !(intersection.width == src_width)) {
+                        if ((intersection.width < intersection.height && intersection.width != src_width) || intersection.height == src_height) {
                             distance_x = intersection.x <= x ? -intersection.width : intersection.width;
                         } else {
                             distance_y = intersection.y <= y ? -intersection.height : intersection.height;

--- a/src/Widgets/DisplaysOverlay.vala
+++ b/src/Widgets/DisplaysOverlay.vala
@@ -486,23 +486,18 @@ public class Display.DisplaysOverlay : Gtk.Overlay {
         snap_widget (display_widget, anchors);
     }
 
-    /**
-     * Widget snaping is done by trying to snap the current widget to other widgets called anchors.
-     * I) At first it is checked if it is possible to snap a widget using only horizontal or
-     * only veritcal translation. This can be done by using four different test_rects which occupy
-     * the area to the left, to the right, at the top and at the bottom of the widget, respectively.
-     * If a test_rect intersects with one of the other anchor_rects the distance to the closest edge
-     * of the anchor get calculated. Afterwards the widgets snaps to the closest anchor.
-     *
-     * Cases:           W = widget, A = current anchor
-     *
-     *   0.        1.        2.        3.
-     *     A W       W A        W         A
-     *                          A         W
-     *
-     * II) If it is not possible to snap the widget horizontally or vertically to any edge,
-     * the widget is snaped diagonally to the nearest corner of an anchor.
-     */
+   /******************************************************************************************
+    *   Widget snaping is done by trying to snap a widget to other widgets called Anchors.   *
+    *   It first calculates the distance between each anchor and the widget, and afterwards  *
+    *   snaps the widget to the closest edge/corner                                          *
+    *                                                                                        *
+    *   Cases:          W = widget, A = current anchor                                       *
+    *                                                                                        *
+    *   1.        2.        3.        4.        5.        6.        7.         8.            *
+    *     A W       W A        A         W         W          W         A         W          *
+    *                          W         A          A        A           W       A           *
+    *                                                                                        *
+    ******************************************************************************************/
 
     private void snap_widget (Display.DisplayWidget widget, List<Display.DisplayWidget> anchors) {
         if (anchors.length () == 0) {


### PR DESCRIPTION
This PR tries to address multiple issues:
1. Introduce magnetic egde to align monitors and avoid small offsets (#95 ,#40, #38.2)
2. If monitors are perfectly aligned window snap is broken (#154)
3. Currently it is possible to create a gap between monitors (#35.1)
4. Currently it is possible to create an overlap/intersection between monitors (#35.2)
5. Releasing the mouse button without moving the widget does not end grab (#34, #35.4)


I also added a label to show the current monitor geometry. Maybe this is too much, but I think it is useful to check if the monitors are properly aligned.

**1./2. Magnetic edge and center:**
![align-monitors](https://user-images.githubusercontent.com/24651767/63471023-6f0bc600-c46e-11e9-8e61-4af9746725e1.gif)
*Can be disabled by pressing <kbd>Ctrl</kbd>*

**3. Close gaps after mouse button release**
![close-gaps](https://user-images.githubusercontent.com/24651767/63471216-d6297a80-c46e-11e9-9abe-e0924d66df2f.gif)
*Should work for all cases with 3 monitors. For 4 and the problem is more complicated.*

**4. Fix intersection for multiple displays:**
![fix-intersections](https://user-images.githubusercontent.com/24651767/63471174-bf832380-c46e-11e9-9b6e-c9237fe98b39.gif)