### PR TITLE
Fix cancelling switch to mirrored

### DIFF
--- a/src/Objects/VirtualMonitor.vala
+++ b/src/Objects/VirtualMonitor.vala
@@ -31,7 +31,7 @@ public class Display.VirtualMonitor : GLib.Object {
 
     public signal void modes_changed ();
 
-    /* 
+    /*
      * Used to distinguish two VirtualMonitors from each other.
      * We make up and ID by sum all hashes of
      * monitors that a VirtualMonitor has.
@@ -59,16 +59,16 @@ public class Display.VirtualMonitor : GLib.Object {
         }
     }
 
-    /* 
+    /*
      * Get the first monitor of the list, handy in non-mirror context.
      */
-    public Display.Monitor monitor {
+    public Display.Monitor? monitor {
         owned get {
             if (is_mirror) {
                 critical ("Do not use Display.VirtualMonitor.monitor in a mirror context!");
             }
 
-            return monitors[0];
+            return monitors.size > 0 ? monitors[0] : null;
         }
     }
 
@@ -80,12 +80,12 @@ public class Display.VirtualMonitor : GLib.Object {
         if (is_mirror) {
             return _("Mirrored Display");
         } else {
-            return monitor.display_name;
+            return monitor != null ? monitor.display_name : "";
         }
     }
 
     public void get_current_mode_size (out int width, out int height) {
-        if (!is_active) {
+        if (!is_active || monitor == null) {
             width = 1280;
             height = 720;
         } else if (is_mirror) {
@@ -108,6 +108,10 @@ public class Display.VirtualMonitor : GLib.Object {
     }
 
     public void set_current_mode (Display.MonitorMode current_mode) {
+        if (monitor == null) {
+            return;
+        }
+
         if (is_mirror) {
             monitors.foreach ((_monitor) => {
                 bool mode_found = false;

--- a/src/Views/DisplaysView.vala
+++ b/src/Views/DisplaysView.vala
@@ -123,14 +123,13 @@ public class Display.DisplaysView : Gtk.Grid {
             });
 
             mirror_switch.active = monitor_manager.is_mirrored;
-            mirror_switch.notify["active"].connect (() => {
-                if (mirror_switch.active) {
-                    monitor_manager.enable_clone_mode ();
-                } else {
-                    monitor_manager.disable_clone_mode ();
-                }
+            monitor_manager.notify["is-mirrored"].connect (() => {
+                mirror_switch.active = monitor_manager.is_mirrored;
+            });
 
-                apply_button.sensitive = true;
+            mirror_switch.notify["active"].connect (() => {
+                apply_button.sensitive = mirror_switch.active && monitor_manager.enable_clone_mode () ||
+                                         !mirror_switch.active && monitor_manager.disable_clone_mode ();
             });
     }
 }


### PR DESCRIPTION
Ensures plug is correctly reset if mirroring is applied but then "Restore previous configuration" is chosen. Applies some armour to prevent some terminal warnings. 

Instead of trying to be too clever when "monitors-changed" signal received from Dbus, just regenerate everything. Optimisations could be remade in future if required as long as they do not cause regressions, but there does not seem to be a performance issue here, so the code is simplified.