### PR TITLE
Deprioritize unrecommended resolutions

### DIFF
--- a/src/Objects/MonitorMode.vala
+++ b/src/Objects/MonitorMode.vala
@@ -33,58 +33,57 @@ public class Display.MonitorMode : GLib.Object {
     private string? resolution_cache = null;
     public unowned string get_resolution () {
         if (resolution_cache == null) {
-            var aspect = make_aspect_string ();
-            if (aspect != null) {
-                resolution_cache = "%u × %u (%s)".printf (width, height, aspect);
-            } else {
-                resolution_cache = "%u × %u".printf (width, height);
-            }
+            resolution_cache = MonitorMode.get_resolution_string (width, height);
         }
 
         return resolution_cache;
     }
 
-    private string? make_aspect_string () {
+    public static string get_resolution_string (int width, int height) {
+        // string aspect;
         int ratio;
         string? aspect = null;
 
-        if (width == 0 || height == 0)
-            return null;
+        if (width > 0 && height > 0) {
+            if (width > height) {
+                ratio = width * 10 / height;
+            } else {
+                ratio = height * 10 / width;
+            }
 
-        if (width > height) {
-            ratio = width * 10 / height;
+            switch (ratio) {
+                case 13:
+                    aspect = "4∶3";
+                    break;
+                case 16:
+                    aspect = "16∶10";
+                    break;
+                case 17:
+                    aspect = "16∶9";
+                    break;
+                case 23:
+                    aspect = "21∶9";
+                    break;
+                case 12:
+                    aspect = "5∶4";
+                    break;
+                    /* This catches 1.5625 as well (1600x1024) when maybe it shouldn't. */
+                case 15:
+                    aspect = "3∶2";
+                    break;
+                case 18:
+                    aspect = "9∶5";
+                    break;
+                case 10:
+                    aspect = "1∶1";
+                    break;
+            }
+        }
+
+        if (aspect != null) {
+            return "%u × %u (%s)".printf (width, height, aspect);
         } else {
-            ratio = height * 10 / width;
+            return "%u × %u".printf (width, height);
         }
-
-        switch (ratio) {
-            case 13:
-                aspect = "4∶3";
-                break;
-            case 16:
-                aspect = "16∶10";
-                break;
-            case 17:
-                aspect = "16∶9";
-                break;
-            case 23:
-                aspect = "21∶9";
-                break;
-            case 12:
-                aspect = "5∶4";
-                break;
-                /* This catches 1.5625 as well (1600x1024) when maybe it shouldn't. */
-            case 15:
-                aspect = "3∶2";
-                break;
-            case 18:
-                aspect = "9∶5";
-                break;
-            case 10:
-                aspect = "1∶1";
-                break;
-        }
-
-        return aspect;
     }
 }

--- a/src/Objects/MonitorMode.vala
+++ b/src/Objects/MonitorMode.vala
@@ -39,12 +39,12 @@ public class Display.MonitorMode : GLib.Object {
         return resolution_cache;
     }
 
-    public static string get_resolution_string (int width, int height) {
+    public static string get_resolution_string (int width, int height, bool include_ratio = true) {
         // string aspect;
         int ratio;
         string? aspect = null;
 
-        if (width > 0 && height > 0) {
+        if (include_ratio && width > 0 && height > 0) {
             if (width > height) {
                 ratio = width * 10 / height;
             } else {

--- a/src/Views/DisplaysView.vala
+++ b/src/Views/DisplaysView.vala
@@ -113,7 +113,7 @@ public class Display.DisplaysView : Gtk.Grid {
             detect_button.clicked.connect (() => displays_overlay.rescan_displays ());
             apply_button.clicked.connect (() => {
                 monitor_manager.set_monitor_config ();
-                apply_button.sensitive = false;
+                apply_button.sensitive = false; //FIXME How can we know whether the change was accepted?
             });
 
             dpi_combo.active = (int)monitor_manager.virtual_monitors[0].scale - 1;

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -109,11 +109,16 @@ public class Display.DisplayWidget : Gtk.EventBox {
             halign = Gtk.Align.END
         };
 
-        selected_resolution_label = new Gtk.Label (virtual_monitor.monitor.current_mode.get_resolution ());
+        selected_resolution_label = new Gtk.Label (virtual_monitor.monitor.current_mode.get_resolution ()) {
+            hexpand = true
+        };
         selected_width = real_width;
         selected_height = real_height;
 
-        var resolution_menubutton = new Gtk.MenuButton ();
+        var resolution_menubutton = new Gtk.MenuButton () {
+            hexpand = false,
+            tooltip_text = _("Select a different screen resolution")
+        };
         var resolution_popover = new Gtk.Popover (resolution_menubutton);
         var resolution_menu = new Menu ();
         var resolution_submenu = new Menu ();
@@ -200,9 +205,9 @@ public class Display.DisplayWidget : Gtk.EventBox {
         popover_grid.attach (selected_resolution_label, 1, 1);
         popover_grid.attach (resolution_menubutton, 2, 1);
         popover_grid.attach (rotation_label, 0, 2);
-        popover_grid.attach (rotation_combobox, 1, 2);
+        popover_grid.attach (rotation_combobox, 1, 2, 2, 1);
         popover_grid.attach (refresh_label, 0, 3);
-        popover_grid.attach (refresh_combobox, 1, 3);
+        popover_grid.attach (refresh_combobox, 1, 3, 2, 1);
         popover_grid.show_all ();
 
         var popover = new Gtk.Popover (toggle_settings);

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -147,17 +147,22 @@ public class Display.DisplayWidget : Gtk.EventBox {
         }
 
         var native_ratio = max_width * 10 / max_height;
-
         // Put less recommended resolutions into a submenu
         foreach (var resolution in resolutions) {
+            // Reject all resolutions incompatible with elementary desktop
+            if (resolution.width < 1024) {
+                continue;
+            }
+
             string? detailed_action = Action.print_detailed_name ("resolution", new Variant ("(ii)", resolution.width, resolution.height));
-            var menu_item = new MenuItem (MonitorMode.get_resolution_string (resolution.width, resolution.height), detailed_action);
 
             if (resolution.aspect == native_ratio && resolution.width >= 1024) {
-                // Recommended
+                // Recommended (native aspect ratio)
+                var menu_item = new MenuItem (MonitorMode.get_resolution_string (resolution.width, resolution.height, false), detailed_action);
                 resolution_menu.append_item (menu_item);
             } else {
                 // Other
+                var menu_item = new MenuItem (MonitorMode.get_resolution_string (resolution.width, resolution.height, true), detailed_action);
                 resolution_submenu.append_item (menu_item);
             }
         }

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -110,6 +110,8 @@ public class Display.DisplayWidget : Gtk.EventBox {
         };
 
         selected_resolution_label = new Gtk.Label (virtual_monitor.monitor.current_mode.get_resolution ());
+        selected_width = real_width;
+        selected_height = real_height;
 
         var resolution_menubutton = new Gtk.MenuButton ();
         var resolution_popover = new Gtk.Popover (resolution_menubutton);
@@ -308,13 +310,15 @@ public class Display.DisplayWidget : Gtk.EventBox {
         refresh_combobox.changed.connect (() => {
             Value val;
             Gtk.TreeIter iter;
-            refresh_combobox.get_active_iter (out iter);
-            refresh_list_store.get_value (iter, RefreshColumns.MODE, out val);
-            Display.MonitorMode new_mode = (Display.MonitorMode) val;
-            virtual_monitor.set_current_mode (new_mode);
-            rotation_combobox.set_active (0);
-            configuration_changed ();
-            check_position ();
+
+            if (refresh_combobox.get_active_iter (out iter)) {
+                refresh_list_store.get_value (iter, RefreshColumns.MODE, out val);
+                Display.MonitorMode new_mode = (Display.MonitorMode) val;
+                virtual_monitor.set_current_mode (new_mode);
+                rotation_combobox.set_active (0);
+                configuration_changed ();
+                check_position ();
+            }
         });
 
         rotation_combobox.set_active ((int) virtual_monitor.transform);
@@ -331,10 +335,14 @@ public class Display.DisplayWidget : Gtk.EventBox {
         if (param != null) {
             int width, height;
             param.@get ("(ii)", out width, out height);
-            if (width > 0 && height > 0) {
+            if ((width > 0 && height > 0) &&
+                 selected_width != width || selected_height != height) {
+
                 selected_width = width;
                 selected_height = height;
                 selected_resolution_label.label = MonitorMode.get_resolution_string (selected_width, selected_height);
+                configuration_changed ();
+                populate_refresh_rates ();
             }
         }
     }

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -367,8 +367,6 @@ public class Display.DisplayWidget : Gtk.EventBox {
     // Set as active the frequency nearest to the current frequency
     private void populate_refresh_rates () {
         double current_frequency = virtual_monitor.monitor.current_mode.frequency;
-        double current_diff = double.MAX;
-        double nearest = current_frequency;
         refresh_list_store.clear ();
 
         Gtk.TreeIter iter;
@@ -397,18 +395,12 @@ public class Display.DisplayWidget : Gtk.EventBox {
             }
 
             frequencies += mode.frequency;
-            var diff = (current_frequency - mode.frequency).abs ();
-            if (diff < current_diff) {
-                current_diff = diff;
-                nearest = mode.frequency;
-            }
-
             var freq_name = _("%g Hz").printf (Math.roundf ((float)mode.frequency));
             refresh_list_store.append (out iter);
             refresh_list_store.set (iter, RefreshColumns.NAME, freq_name, RefreshColumns.MODE, mode);
             added++;
 
-            if (mode.frequency == nearest) {
+            if (mode.frequency == current_frequency) {
                 refresh_combobox.set_active_iter (iter);
             }
         }

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -176,7 +176,7 @@ public class Display.DisplayWidget : Gtk.EventBox {
             resolution_menu.append_submenu (_("Other…"), resolution_submenu);
         }
 
-        if (usable_resolutions > 0) {
+        if (usable_resolutions > 1) { // Only need menu if there is a choice
             resolution_popover.bind_model (resolution_menu, "app");
             resolution_popover.show_all ();
             resolution_menubutton.set_popover (resolution_popover);

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -148,6 +148,7 @@ public class Display.DisplayWidget : Gtk.EventBox {
 
         var native_ratio = max_width * 10 / max_height;
 
+        // Put less recommended resolutions into a submenu
         foreach (var resolution in resolutions) {
             string? detailed_action = Action.print_detailed_name ("resolution", new Variant ("(ii)", resolution.width, resolution.height));
             var menu_item = new MenuItem (MonitorMode.get_resolution_string (resolution.width, resolution.height), detailed_action);
@@ -163,8 +164,7 @@ public class Display.DisplayWidget : Gtk.EventBox {
 
         resolution_menu.append_submenu (_("Other…"), resolution_submenu);
 
-        string? action_namespace = "app";
-        resolution_popover.bind_model (resolution_menu, action_namespace);
+        resolution_popover.bind_model (resolution_menu, "app");
 
         resolution_popover.show_all ();
         resolution_menubutton.set_popover (resolution_popover);

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -132,6 +132,8 @@ public class Display.DisplayWidget : Gtk.EventBox {
         int max_width = -1;
         int max_height = -1;
         bool resolution_set = false;
+        uint usable_resolutions = 0;
+        uint other_resolutions = 0;
         foreach (var mode in virtual_monitor.get_available_modes ()) {
             var mode_width = mode.width;
             var mode_height = mode.height;
@@ -164,15 +166,21 @@ public class Display.DisplayWidget : Gtk.EventBox {
                 // Other
                 var menu_item = new MenuItem (MonitorMode.get_resolution_string (resolution.width, resolution.height, true), detailed_action);
                 resolution_submenu.append_item (menu_item);
+                other_resolutions++;
             }
+
+            usable_resolutions++;
         }
 
-        resolution_menu.append_submenu (_("Other…"), resolution_submenu);
+        if (other_resolutions > 0) {
+            resolution_menu.append_submenu (_("Other…"), resolution_submenu);
+        }
 
-        resolution_popover.bind_model (resolution_menu, "app");
-
-        resolution_popover.show_all ();
-        resolution_menubutton.set_popover (resolution_popover);
+        if (usable_resolutions > 0) {
+            resolution_popover.bind_model (resolution_menu, "app");
+            resolution_popover.show_all ();
+            resolution_menubutton.set_popover (resolution_popover);
+        }
 
         var rotation_label = new Gtk.Label (_("Screen Rotation:"));
         rotation_label.halign = Gtk.Align.END;

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -343,11 +343,22 @@ public class Display.DisplayWidget : Gtk.EventBox {
             if ((width > 0 && height > 0) &&
                  selected_width != width || selected_height != height) {
 
-                selected_width = width;
-                selected_height = height;
-                selected_resolution_label.label = MonitorMode.get_resolution_string (selected_width, selected_height);
-                configuration_changed ();
-                populate_refresh_rates ();
+                foreach (var mode in virtual_monitor.get_available_modes ()) {
+                    if (mode.width == width && mode.height == height) {
+                        selected_width = width;
+                        selected_height = height;
+                        selected_resolution_label.label = MonitorMode.get_resolution_string (selected_width, selected_height);
+
+                        set_geometry (virtual_monitor.x, virtual_monitor.y, (int)mode.width, (int)mode.height);
+                        virtual_monitor.set_current_mode (mode);
+                        rotation_combobox.set_active (0);
+
+                        configuration_changed ();
+                        populate_refresh_rates ();
+
+                        break; // The resolution list takes the first available mode for each size
+                    }
+                }
             }
         }
     }
@@ -419,6 +430,8 @@ public class Display.DisplayWidget : Gtk.EventBox {
             selected_width = mode.width;
             selected_height = mode.height;
             selected_resolution_label.label = MonitorMode.get_resolution_string (selected_width, selected_height);
+
+            populate_refresh_rates ();
         }
     }
 

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -119,6 +119,8 @@ public class Display.DisplayWidget : Gtk.EventBox {
             hexpand = false,
             tooltip_text = _("Select a different screen resolution")
         };
+
+        resolution_menubutton.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         var resolution_popover = new Gtk.Popover (resolution_menubutton);
         var resolution_menu = new Menu ();
         var resolution_submenu = new Menu ();

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -152,7 +152,7 @@ public class Display.DisplayWidget : Gtk.EventBox {
         // Put less recommended resolutions into a submenu
         foreach (var resolution in resolutions) {
             // Reject all resolutions incompatible with elementary desktop
-            if (resolution.width < 1024) {
+            if (resolution.width < 1024 || resolution.height < 768) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes #178 
Fixes #252 

The resolution combobox is replaced by a MenuButton/Popover built from a MenuModel.  This allows less recommended resolutions to be put in a submenu.  The main menu just shows resolutions with native aspect ratio and width >= 1024 px.

If this design is accepted, then the other two comboboxes can be replaced by a similar design for consistency either in this PR on in further PRs.