### PR TITLE
Remove offsets from virtual monitors

### DIFF
--- a/src/Objects/MonitorManager.vala
+++ b/src/Objects/MonitorManager.vala
@@ -234,6 +234,24 @@ public class Display.MonitorManager : GLib.Object {
             }
         }
 
+        int min_x = int.MAX;
+        int min_y = int.MAX;
+
+        // Make sure the remaining enabled monitors start at 0,0 as required by mutter.
+        // Calculate their offset, and then offset them if necessary
+        foreach (var logical_monitor in logical_monitors) {
+            min_x = int.min (min_x, logical_monitor.x);
+            min_y = int.min (min_y, logical_monitor.y);
+        }
+
+        if (min_x != 0 || min_y != 0) {
+            // Iterate over the items in the array directly here, a `foreach` would return a copy
+            for (int i = 0; i < logical_monitors.length; i++) {
+                logical_monitors[i].x -= min_x;
+                logical_monitors[i].y -= min_y;
+            }
+        }
+
         var properties = new GLib.HashTable<string, GLib.Variant> (str_hash, str_equal);
         try {
             iface.apply_monitors_config (current_serial, MutterApplyMethod.PERSISTENT, logical_monitors, properties);

--- a/src/Objects/MonitorManager.vala
+++ b/src/Objects/MonitorManager.vala
@@ -239,7 +239,7 @@ public class Display.MonitorManager : GLib.Object {
 
         // Make sure the remaining enabled monitors start at 0,0 as required by mutter.
         // Calculate their offset, and then offset them if necessary
-        foreach (var logical_monitor in logical_monitors) {
+        foreach (unowned var logical_monitor in logical_monitors) {
             min_x = int.min (min_x, logical_monitor.x);
             min_y = int.min (min_y, logical_monitor.y);
         }

--- a/src/Objects/VirtualMonitor.vala
+++ b/src/Objects/VirtualMonitor.vala
@@ -31,7 +31,7 @@ public class Display.VirtualMonitor : GLib.Object {
 
     public signal void modes_changed ();
 
-    /* 
+    /*
      * Used to distinguish two VirtualMonitors from each other.
      * We make up and ID by sum all hashes of
      * monitors that a VirtualMonitor has.
@@ -55,7 +55,7 @@ public class Display.VirtualMonitor : GLib.Object {
 
     public bool is_active { get; set; default = true; }
 
-    /* 
+    /*
      * Get the first monitor of the list, handy in non-mirror context.
      */
     public Display.Monitor monitor {
@@ -82,6 +82,17 @@ public class Display.VirtualMonitor : GLib.Object {
 
     public void get_current_mode_size (out int width, out int height) {
         if (!is_active) {
+            // If the monitor isn't active, return the preferred mode as this will be the default
+            // mode when the monitor is re-activated
+            foreach (var mode in monitor.modes) {
+                if (mode.is_preferred) {
+                    width = mode.width;
+                    height = mode.height;
+                    return;
+                }
+            }
+
+            // Last resort fallback if no preferred mode
             width = 1280;
             height = 720;
         } else if (is_mirror) {


### PR DESCRIPTION
Fixes #314 

Follow up to #311 

It wasn't possible to disable monitors on the left or above the other enabled monitors as doing so would leave a gap in the "virtual monitors" co-ordinate space where mutter expects them to start from 0,0.

So, once we've filtered out the disabled monitors, offset them by their minimum co-ordinate to get them arranged around 0,0.

I've additionally made `get_current_mode_size` return the preferred size for disabled monitors instead of a hardcoded value, which makes positioning and re-enabling disabled monitors easier.