### PR TITLE
Prefer the resolution modes marked is_preferred

### DIFF
--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -22,6 +22,7 @@ public struct Display.Resolution {
     int width;
     int height;
     int aspect;
+    bool is_preferred;
 }
 
 public class Display.DisplayWidget : Gtk.EventBox {
@@ -174,13 +175,19 @@ public class Display.DisplayWidget : Gtk.EventBox {
             resolution_set.add (mode); // Ensures resolutions unique and sorted
         }
 
+        bool has_preferred = false;
+
         foreach (var mode in resolution_set) {
             var mode_width = mode.width;
             var mode_height = mode.height;
             max_width = int.max (max_width, mode_width);
             max_height = int.max (max_height, mode_height);
 
-            Resolution res = {mode_width, mode_height, mode_width * 10 / mode_height};
+            if (mode.is_preferred) {
+                has_preferred = true;
+            }
+
+            Resolution res = {mode_width, mode_height, mode_width * 10 / mode_height, mode.is_preferred};
             resolutions += res;
         }
 
@@ -192,7 +199,7 @@ public class Display.DisplayWidget : Gtk.EventBox {
                 continue;
             }
 
-            if (resolution.aspect == native_ratio) {
+            if ((has_preferred && resolution.is_preferred) || (!has_preferred && (resolution.aspect == native_ratio))) {
                 // Recommended (native aspect ratio)
                 recommended_resolutions += resolution;
             } else {

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -164,7 +164,6 @@ public class Display.DisplayWidget : Gtk.EventBox {
         // Build resolution menu
         // First, get list of unique resolutions from available modes.
         Resolution[] resolutions = {};
-        Resolution[] preferred_resolutions = {};
         Resolution[] recommended_resolutions = {};
         Resolution[] other_resolutions = {};
         int max_width = -1;
@@ -197,27 +196,13 @@ public class Display.DisplayWidget : Gtk.EventBox {
                 continue;
             }
 
-            if (resolution.is_preferred || resolution.is_current) {
-                preferred_resolutions += resolution;
-            } else if (resolution.aspect == native_ratio) {
-                // Recommended (native aspect ratio)
+            if (resolution.is_preferred || resolution.is_current || resolution.aspect == native_ratio) {
                 recommended_resolutions += resolution;
             } else {
-                // Other
                 other_resolutions += resolution;
             }
 
             usable_resolutions++;
-        }
-
-        foreach (var resolution in preferred_resolutions) {
-            Gtk.TreeIter iter;
-            resolution_tree_store.append (out iter, null);
-            resolution_tree_store.set (iter,
-                ResolutionColumns.NAME, MonitorMode.get_resolution_string (resolution.width, resolution.height, false),
-                ResolutionColumns.WIDTH, resolution.width,
-                ResolutionColumns.HEIGHT, resolution.height
-            );
         }
 
         foreach (var resolution in recommended_resolutions) {

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -23,6 +23,7 @@ public struct Display.Resolution {
     int height;
     int aspect;
     bool is_preferred;
+    bool is_current;
 }
 
 public class Display.DisplayWidget : Gtk.EventBox {
@@ -179,10 +180,12 @@ public class Display.DisplayWidget : Gtk.EventBox {
         foreach (var mode in resolution_set) {
             var mode_width = mode.width;
             var mode_height = mode.height;
-            max_width = int.max (max_width, mode_width);
-            max_height = int.max (max_height, mode_height);
+            if (mode.is_preferred) {
+                max_width = int.max (max_width, mode_width);
+                max_height = int.max (max_height, mode_height);
+            }
 
-            Resolution res = {mode_width, mode_height, mode_width * 10 / mode_height, mode.is_preferred};
+            Resolution res = {mode_width, mode_height, mode_width * 10 / mode_height, mode.is_preferred, mode.is_current};
             resolutions += res;
         }
 
@@ -194,7 +197,7 @@ public class Display.DisplayWidget : Gtk.EventBox {
                 continue;
             }
 
-            if (resolution.is_preferred) {
+            if (resolution.is_preferred || resolution.is_current) {
                 preferred_resolutions += resolution;
             } else if (resolution.aspect == native_ratio) {
                 // Recommended (native aspect ratio)
@@ -485,6 +488,7 @@ public class Display.DisplayWidget : Gtk.EventBox {
     }
 
     private bool set_active_resolution_from_current_mode () {
+        bool result = false;
         foreach (var mode in virtual_monitor.get_available_modes ()) {
             if (!mode.is_current) {
                 continue;
@@ -498,6 +502,7 @@ public class Display.DisplayWidget : Gtk.EventBox {
                 );
                 if (mode.width == width && mode.height == height) {
                     resolution_combobox.set_active_iter (iter);
+                    result = true;
                     return true;
                 }
 
@@ -505,7 +510,7 @@ public class Display.DisplayWidget : Gtk.EventBox {
             });
         }
 
-        return false;
+        return result;
     }
 
     private void on_vm_transform_changed () {


### PR DESCRIPTION
Fixes #338 

This patch checks whether the `is_preferred` flag has been set on any of the modes and if so then only add those modes to the recommended resolution list and the rest to the other list.

If none of the modes have the `is_preferred` flag set to true then the current behaviour is maintained.

Current behaviour (before this patch) is that the max supported resolutions aspect ratio (not necessarily native) are placed into the recommended list with undesirable (?) results, at least on my 4K UHD (3840x2160) TV with native aspect ratio of 16:9

See the before and after screenshots:

BEFORE:

![display_before_cropped](https://user-images.githubusercontent.com/612302/212533919-b7e231a6-49c2-4d23-a578-1f39485f6d08.jpeg)

AFTER:

![display_after_cropped](https://user-images.githubusercontent.com/612302/212533925-5aff6eb2-60ab-41af-a9a2-a83545715012.jpeg)
