### PR TITLE
Add missing deeplink handlers

### DIFF
--- a/src/DisplayPlug.vala
+++ b/src/DisplayPlug.vala
@@ -31,8 +31,9 @@ public class Display.Plug : Switchboard.Plug {
         GLib.Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 
         var settings = new Gee.TreeMap<string, string?> (null, null);
-        settings.set ("display", null);
+        settings.set ("display", "displays");
         settings.set ("display/night-light", "night-light");
+        settings.set ("display/filters", "filters");
         Object (category: Category.HARDWARE,
                 code_name: "io.elementary.switchboard.display",
                 display_name: _("Displays"),


### PR DESCRIPTION
Adds handlers for the following "deeplinks" (not sure what the conventional term is!):

- `settings://display` - To the `Displays` tab
- `settings://display/filters` - To the `Filters` tab.

This should allow the app menu to correctly open this plug at the correct tab from search results, as referenced in #360 