### PR TITLE
DisplayWidget: Fix text-shadow for children 

### DIFF
--- a/data/Display.css
+++ b/data/Display.css
@@ -1,11 +1,11 @@
 display-widget {
     border-radius: 3px;
     padding: 6px;
-    text-shadow: 0 1px 1px alpha(white, 0.1);
     -gtk-icon-shadow: 0 1px 1px alpha(white, 0.1);
 }
 
 display-widget > grid > label {
+    text-shadow: 0 1px 1px alpha(white, 0.1);
     font-weight: 600;
 }
 


### PR DESCRIPTION
The labels inside the popover for display configuration had also the text shadow applied which made them look very blurry. Make sure we only apply the text shadow to the centered label of the display widget.