### PR TITLE
Fix Scale set by adding modes before set calling

### DIFF
--- a/src/Objects/MonitorManager.vala
+++ b/src/Objects/MonitorManager.vala
@@ -222,7 +222,7 @@ public class Display.MonitorManager : GLib.Object {
             bool found = false;
             foreach (var virtual_monitor in virtual_monitors) {
                 if (monitor in virtual_monitor.monitors) {
-                    found = true;
+                   found = true;
                     break;
                 }
             }
@@ -232,8 +232,8 @@ public class Display.MonitorManager : GLib.Object {
                 add_virtual_monitor (virtual_monitor);
                 virtual_monitor.is_active = false;
                 virtual_monitor.primary = false;
-                virtual_monitor.scale = virtual_monitors[0].scale;
                 virtual_monitor.monitors.add (monitor);
+                virtual_monitor.scale = virtual_monitors[0].scale;
             }
         }
     }

--- a/src/Objects/VirtualMonitor.vala
+++ b/src/Objects/VirtualMonitor.vala
@@ -150,7 +150,7 @@ public class Display.VirtualMonitor : GLib.Object {
     private void update_available_scales () {
         Scale[] scales = {};
         foreach (var mode in get_available_modes ()) {
-            if (!mode.is_current) {
+            if (!mode.is_current && !mode.is_preferred) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes #411 

1. We need to set modes to a inactive monitor before setting scale because it depends on monitor modes to properly set it
2. Set a prefered scale to a monitor even it's not active
