### PR TITLE
Fix crash on enabling mirror display

### DIFF
--- a/src/Objects/MonitorManager.vala
+++ b/src/Objects/MonitorManager.vala
@@ -222,7 +222,7 @@ public class Display.MonitorManager : GLib.Object {
             bool found = false;
             foreach (var virtual_monitor in virtual_monitors) {
                 if (monitor in virtual_monitor.monitors) {
-                   found = true;
+                    found = true;
                     break;
                 }
             }
@@ -232,8 +232,8 @@ public class Display.MonitorManager : GLib.Object {
                 add_virtual_monitor (virtual_monitor);
                 virtual_monitor.is_active = false;
                 virtual_monitor.primary = false;
-                virtual_monitor.monitors.add (monitor);
                 virtual_monitor.scale = virtual_monitors[0].scale;
+                virtual_monitor.monitors.add (monitor);
             }
         }
     }

--- a/src/Objects/MonitorManager.vala
+++ b/src/Objects/MonitorManager.vala
@@ -297,8 +297,8 @@ public class Display.MonitorManager : GLib.Object {
     public void enable_clone_mode () {
         var clone_virtual_monitor = new Display.VirtualMonitor ();
         clone_virtual_monitor.primary = true;
-        clone_virtual_monitor.scale = Utils.get_min_compatible_scale (monitors);
         clone_virtual_monitor.monitors.add_all (monitors);
+        clone_virtual_monitor.scale = Utils.get_min_compatible_scale (monitors);
         var modes = clone_virtual_monitor.get_available_modes ();
         /*
          * Two choices here:
@@ -364,6 +364,9 @@ public class Display.MonitorManager : GLib.Object {
             var single_virtual_monitor = new Display.VirtualMonitor ();
             var preferred_mode = monitor.preferred_mode;
             var current_mode = monitor.current_mode;
+
+            single_virtual_monitor.monitors.add (monitor);
+
             if (global_scale_required) {
                 single_virtual_monitor.scale = max_scale;
                 if (max_scale in preferred_mode.supported_scales) {
@@ -388,7 +391,6 @@ public class Display.MonitorManager : GLib.Object {
                 single_virtual_monitor.scale = preferred_mode.preferred_scale;
             }
 
-            single_virtual_monitor.monitors.add (monitor);
             new_virtual_monitors.add (single_virtual_monitor);
         }
 

--- a/src/Objects/MonitorManager.vala
+++ b/src/Objects/MonitorManager.vala
@@ -222,7 +222,7 @@ public class Display.MonitorManager : GLib.Object {
             bool found = false;
             foreach (var virtual_monitor in virtual_monitors) {
                 if (monitor in virtual_monitor.monitors) {
-                    found = true;
+                   found = true;
                     break;
                 }
             }
@@ -232,8 +232,8 @@ public class Display.MonitorManager : GLib.Object {
                 add_virtual_monitor (virtual_monitor);
                 virtual_monitor.is_active = false;
                 virtual_monitor.primary = false;
-                virtual_monitor.scale = virtual_monitors[0].scale;
                 virtual_monitor.monitors.add (monitor);
+                virtual_monitor.scale = virtual_monitors[0].scale;
             }
         }
     }

--- a/src/Objects/VirtualMonitor.vala
+++ b/src/Objects/VirtualMonitor.vala
@@ -150,7 +150,7 @@ public class Display.VirtualMonitor : GLib.Object {
     private void update_available_scales () {
         Scale[] scales = {};
         foreach (var mode in get_available_modes ()) {
-            if (!mode.is_current && !mode.is_preferred) {
+            if (!mode.is_current) {
                 continue;
             }
 

--- a/src/Objects/VirtualMonitor.vala
+++ b/src/Objects/VirtualMonitor.vala
@@ -150,7 +150,7 @@ public class Display.VirtualMonitor : GLib.Object {
     private void update_available_scales () {
         Scale[] scales = {};
         foreach (var mode in get_available_modes ()) {
-            if (!mode.is_current) {
+            if (!mode.is_current && !mode.is_preferred) {
                 continue;
             }
 

--- a/src/Widgets/DisplaysOverlay.vala
+++ b/src/Widgets/DisplaysOverlay.vala
@@ -186,10 +186,12 @@ public class Display.DisplaysOverlay : Gtk.Box {
 
     public void rescan_displays () {
         scanning = true;
-        foreach (unowned var widget in display_widgets) {
-            display_widgets.remove (widget);
-            widget.destroy ();
-        }
+
+        display_widgets.@foreach ((display_widget) => {
+                overlay.remove_overlay (display_widget);
+                display_widget.destroy ();
+                display_widgets.remove (display_widget);
+        });
 
         active_displays = 0;
         foreach (var virtual_monitor in monitor_manager.virtual_monitors) {

--- a/src/Widgets/DisplaysOverlay.vala
+++ b/src/Widgets/DisplaysOverlay.vala
@@ -188,9 +188,9 @@ public class Display.DisplaysOverlay : Gtk.Box {
         scanning = true;
 
         display_widgets.@foreach ((display_widget) => {
-                overlay.remove_overlay (display_widget);
-                display_widget.destroy ();
-                display_widgets.remove (display_widget);
+            overlay.remove_overlay (display_widget);
+            display_widget.destroy ();
+            display_widgets.remove (display_widget);
         });
 
         active_displays = 0;


### PR DESCRIPTION
Fixes #374 
Closes #406 

- Sets monitores before scale setting
- Fix overlay not being updated after enable mirrored display
- Fix display widgets removing at overlay update 