### PR TITLE
Fix crash and display arrangement when pluging new monitor

### DIFF
--- a/src/Objects/MonitorManager.vala
+++ b/src/Objects/MonitorManager.vala
@@ -83,6 +83,10 @@ public class Display.MonitorManager : GLib.Object {
             critical (e.message);
         }
 
+        // Clear all monitors and virtual monitors before re-adding them if needed
+        monitors.clear ();
+        virtual_monitors.clear ();
+
         //TODO: make use of the "global-scale-required" property to differenciate between X and Wayland
         var supports_mirroring_variant = properties.lookup ("supports-mirroring");
         if (supports_mirroring_variant != null) {
@@ -188,7 +192,6 @@ public class Display.MonitorManager : GLib.Object {
             var virtual_monitor = get_virtual_monitor_by_id (monitors_id);
             if (virtual_monitor == null) {
                 virtual_monitor = new VirtualMonitor ();
-                add_virtual_monitor (virtual_monitor);
             }
 
             foreach (var mutter_info in mutter_logical_monitor.monitors) {
@@ -214,6 +217,7 @@ public class Display.MonitorManager : GLib.Object {
             virtual_monitor.scale = mutter_logical_monitor.scale;
             virtual_monitor.transform = mutter_logical_monitor.transform;
             virtual_monitor.primary = mutter_logical_monitor.primary;
+            add_virtual_monitor (virtual_monitor);
         }
 
         // Look for any monitors that aren't part of a virtual monitor (hence disabled)
@@ -229,11 +233,11 @@ public class Display.MonitorManager : GLib.Object {
 
             if (!found) {
                 var virtual_monitor = new VirtualMonitor ();
-                add_virtual_monitor (virtual_monitor);
                 virtual_monitor.is_active = false;
                 virtual_monitor.primary = false;
                 virtual_monitor.monitors.add (monitor);
                 virtual_monitor.scale = virtual_monitors[0].scale;
+                add_virtual_monitor (virtual_monitor);
             }
         }
     }

--- a/src/Views/DisplaysView.vala
+++ b/src/Views/DisplaysView.vala
@@ -9,7 +9,7 @@
 public class Display.DisplaysView : Gtk.Box {
     public DisplaysOverlay displays_overlay;
 
-    private Gtk.ComboBoxText dpi_combo;
+    private Gtk.DropDown dpi_combo;
     private Gtk.Box rotation_lock_box;
 
     private const string TOUCHSCREEN_SETTINGS_PATH = "org.gnome.settings-daemon.peripherals.touchscreen";
@@ -34,10 +34,16 @@ public class Display.DisplaysView : Gtk.Box {
 
             var dpi_label = new Gtk.Label (_("Scaling factor:"));
 
-            dpi_combo = new Gtk.ComboBoxText ();
-            dpi_combo.append_text (_("LoDPI") + " (1×)");
-            dpi_combo.append_text (_("HiDPI") + " (2×)");
-            dpi_combo.append_text (_("HiDPI") + " (3×)");
+            var dpi_dropdown_options = new string[3] {
+                _("LoDPI") + " (1×)",
+                _("HiDPI") + " (2×)",
+                _("HiDPI") + " (3×)"
+            };
+
+            dpi_combo = new Gtk.DropDown (new Gtk.StringList (dpi_dropdown_options), null);
+            //dpi_combo.append_text (_("LoDPI") + " (1×)");
+            //dpi_combo.append_text (_("HiDPI") + " (2×)");
+            //dpi_combo.append_text (_("HiDPI") + " (3×)");
 
             var dpi_box = new Gtk.Box (HORIZONTAL, 6) {
                 margin_top = 6,
@@ -130,11 +136,11 @@ public class Display.DisplaysView : Gtk.Box {
                 apply_button.sensitive = false;
             });
 
-            dpi_combo.active = (int)monitor_manager.virtual_monitors[0].scale - 1;
+            dpi_combo.selected = (int)monitor_manager.virtual_monitors[0].scale - 1;
 
-            dpi_combo.changed.connect (() => {
+            dpi_combo.activate.connect (() => {
                 try {
-                    monitor_manager.set_scale_on_all_monitors ((double)(dpi_combo.active + 1));
+                    monitor_manager.set_scale_on_all_monitors ((double)(dpi_combo.selected + 1));
                 } catch (Error e) {
                     show_error_dialog (e.message);
                 }

--- a/src/Views/DisplaysView.vala
+++ b/src/Views/DisplaysView.vala
@@ -9,7 +9,7 @@
 public class Display.DisplaysView : Gtk.Box {
     public DisplaysOverlay displays_overlay;
 
-    private Gtk.DropDown dpi_combo;
+    private Gtk.ComboBoxText dpi_combo;
     private Gtk.Box rotation_lock_box;
 
     private const string TOUCHSCREEN_SETTINGS_PATH = "org.gnome.settings-daemon.peripherals.touchscreen";
@@ -34,16 +34,10 @@ public class Display.DisplaysView : Gtk.Box {
 
             var dpi_label = new Gtk.Label (_("Scaling factor:"));
 
-            var dpi_dropdown_options = new string[3] {
-                _("LoDPI") + " (1×)",
-                _("HiDPI") + " (2×)",
-                _("HiDPI") + " (3×)"
-            };
-
-            dpi_combo = new Gtk.DropDown (new Gtk.StringList (dpi_dropdown_options), null);
-            //dpi_combo.append_text (_("LoDPI") + " (1×)");
-            //dpi_combo.append_text (_("HiDPI") + " (2×)");
-            //dpi_combo.append_text (_("HiDPI") + " (3×)");
+            dpi_combo = new Gtk.ComboBoxText ();
+            dpi_combo.append_text (_("LoDPI") + " (1×)");
+            dpi_combo.append_text (_("HiDPI") + " (2×)");
+            dpi_combo.append_text (_("HiDPI") + " (3×)");
 
             var dpi_box = new Gtk.Box (HORIZONTAL, 6) {
                 margin_top = 6,
@@ -136,11 +130,11 @@ public class Display.DisplaysView : Gtk.Box {
                 apply_button.sensitive = false;
             });
 
-            dpi_combo.selected = (int)monitor_manager.virtual_monitors[0].scale - 1;
+            dpi_combo.active = (int)monitor_manager.virtual_monitors[0].scale - 1;
 
-            dpi_combo.activate.connect (() => {
+            dpi_combo.changed.connect (() => {
                 try {
-                    monitor_manager.set_scale_on_all_monitors ((double)(dpi_combo.selected + 1));
+                    monitor_manager.set_scale_on_all_monitors ((double)(dpi_combo.active + 1));
                 } catch (Error e) {
                     show_error_dialog (e.message);
                 }


### PR DESCRIPTION
Fixes #419 by creating adding a new monitor when we already finished setup it and fixes the display arrangement when adding or removing a monitor.