### PR TITLE
Apply scaling to virtual monitor reported size

### DIFF
--- a/src/Objects/VirtualMonitor.vala
+++ b/src/Objects/VirtualMonitor.vala
@@ -119,23 +119,23 @@ public class Display.VirtualMonitor : GLib.Object {
             // mode when the monitor is re-activated
             foreach (var mode in monitor.modes) {
                 if (mode.is_preferred) {
-                    width = scaled(mode.width);
-                    height = scaled(mode.height);
+                    width = apply_current_scale (mode.width);
+                    height = apply_current_scale (mode.height);
                     return;
                 }
             }
 
             // Last resort fallback if no preferred mode
-            width = scaled(1280);
-            height = scaled(720);
+            width = apply_current_scale (1280);
+            height = apply_current_scale (720);
         } else if (is_mirror) {
             var current_mode = monitors[0].current_mode;
-            width = scaled(current_mode.width);
-            height = scaled(current_mode.height);
+            width = apply_current_scale (current_mode.width);
+            height = apply_current_scale (current_mode.height);
         } else {
             var current_mode = monitor.current_mode;
-            width = scaled(current_mode.width);
-            height = scaled(current_mode.height);
+            width = apply_current_scale (current_mode.width);
+            height = apply_current_scale (current_mode.height);
         }
     }
 
@@ -217,7 +217,7 @@ public class Display.VirtualMonitor : GLib.Object {
      * @param dimension The monitor dimension to scale (width or height) by the current `scale` factor
      * @return the dimension scaled then rounded up and converted back to int
      */
-    private int scaled (int dimension) {
+    private int apply_current_scale (int dimension) {
         return (int) Math.ceil (dimension / scale);
     }
 }

--- a/src/Objects/VirtualMonitor.vala
+++ b/src/Objects/VirtualMonitor.vala
@@ -59,7 +59,7 @@ public class Display.VirtualMonitor : GLib.Object {
         }
     }
 
-    /*
+    /**
      * Used to distinguish two VirtualMonitors from each other.
      * We make up and ID by sum all hashes of
      * monitors that a VirtualMonitor has.
@@ -83,7 +83,7 @@ public class Display.VirtualMonitor : GLib.Object {
 
     public bool is_active { get; set; default = true; }
 
-    /*
+    /**
      * Get the first monitor of the list, handy in non-mirror context.
      */
     public Display.Monitor monitor {
@@ -119,23 +119,23 @@ public class Display.VirtualMonitor : GLib.Object {
             // mode when the monitor is re-activated
             foreach (var mode in monitor.modes) {
                 if (mode.is_preferred) {
-                    width = mode.width;
-                    height = mode.height;
+                    width = scaled(mode.width);
+                    height = scaled(mode.height);
                     return;
                 }
             }
 
             // Last resort fallback if no preferred mode
-            width = 1280;
-            height = 720;
+            width = scaled(1280);
+            height = scaled(720);
         } else if (is_mirror) {
             var current_mode = monitors[0].current_mode;
-            width = current_mode.width;
-            height = current_mode.height;
+            width = scaled(current_mode.width);
+            height = scaled(current_mode.height);
         } else {
             var current_mode = monitor.current_mode;
-            width = current_mode.width;
-            height = current_mode.height;
+            width = scaled(current_mode.width);
+            height = scaled(current_mode.height);
         }
     }
 
@@ -210,5 +210,14 @@ public class Display.VirtualMonitor : GLib.Object {
         }
 
         return val.to_string ();
+    }
+
+    /**
+     * Apply scaling, to avoid gaps between virtual monitors in the configuration
+     * @param dimension The monitor dimension to scale (width or height) by the current `scale` factor
+     * @return the dimension scaled then rounded up and converted back to int
+     */
+    private int scaled (int dimension) {
+        return (int) Math.ceil (dimension / scale);
     }
 }

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -433,7 +433,9 @@ public class Display.DisplayWidget : Gtk.Box {
             // Prevent breaking autohide by closing popover
             popover.popdown ();
 
+            virtual_monitor.get_current_mode_size (out real_height, out real_width);
             configuration_changed ();
+            check_position ();
         });
 
         rotation_combobox.set_active ((int) virtual_monitor.transform);


### PR DESCRIPTION
This fixes an issue where you could not apply a layout where a monitor on the left or on top of another monitor has scaling over 100%, because the configuration would contain gaps and the following error would be raised:
<img width="590" height="328" alt="image" src="https://github.com/user-attachments/assets/ae775fea-ee13-4a58-8932-0366f0237005" />
This is because the screen origin is at its top-left. When scaling is applied, the monitor area is smaller, which creates gaps on its right and bottom sides that were not took into account.

This PR resize the monitor area when scaling is modified, logically and visually, so the monitor can be adjacent. Moreover, the user can now see what the real area of the monitor will be.

I did not found an existing issue reporting this, but it could related to #435.

