### PR TITLE
Avoid resetting rotation and scale on refresh rate modification

### DIFF
--- a/src/Objects/VirtualMonitor.vala
+++ b/src/Objects/VirtualMonitor.vala
@@ -200,7 +200,11 @@ public class Display.VirtualMonitor : GLib.Object {
             }
         }
 
-        scale = current_mode.preferred_scale;
+        // Set default scale if the current scale is not present anymore in the available ones
+        if (!is_scale_available ()) {
+            info ("Previous scaling is not present in the new availables scales, defaulting to the preferred one\n");
+            scale = current_mode.preferred_scale;
+        }
     }
 
     public static string generate_id_from_monitors (MutterReadMonitorInfo[] infos) {
@@ -219,5 +223,19 @@ public class Display.VirtualMonitor : GLib.Object {
      */
     private int apply_current_scale (int dimension) {
         return (int) Math.ceil (dimension / scale);
+    }
+
+    /**
+     * Check if the current scale value is available in current available scales
+     * @return true if the current scale value is present in available_scales_store, false otherwise
+     */
+    private bool is_scale_available () {
+        for (uint i = available_scales_store.get_n_items (); i-- > 0; ) {
+            var new_scale = (Scale) available_scales_store.get_item (i);
+            if (new_scale != null && scale == new_scale.scale) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -423,7 +423,6 @@ public class Display.DisplayWidget : Gtk.Box {
                 refresh_list_store.get_value (iter, RefreshColumns.VALUE, out val);
                 Display.MonitorMode new_mode = (Display.MonitorMode) val;
                 virtual_monitor.set_current_mode (new_mode);
-                rotation_combobox.set_active (0);
                 configuration_changed ();
                 check_position ();
             }


### PR DESCRIPTION
When changing a virtual monitor refresh rate (without applying), the rotation and scaling were set to their default value (respectively no rotation and mode preferred).

This modification checks if the scale is still available when changing mode by changing the refresh rate. If so, it does not update the scale to the preferred one anymore.
It uses exact comparison between floats, so the slightest difference of value will trigger the use of the preferred scale. For example my 125% scale value is "1.248780". I can update this behaviour if needed, using a "allowed gap" for two "similar" scales.

Also remove explicit rotation reset to "0".